### PR TITLE
#61-fixing broken things in docs 

### DIFF
--- a/docs/About.md
+++ b/docs/About.md
@@ -4,7 +4,7 @@ The app is primarily for the benefit of Northeastern Electric Racing's Project M
 
 ## Product Management
 
-See the [product management](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/Docs/ProductManagement.md) document for a comprehensive understanding of the project's purpose.
+See the [product management](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ProductManagement.md) document for a comprehensive understanding of the project's purpose.
 
 ## Tech Stack
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-&-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues And Suggesting Features
+## Creating Issues & Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-/-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues/Suggesting Features
+## Creating Issues / Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues & Suggesting Features
+## Creating Issues And Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-&-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues And Suggesting Features
+## Creating Issues & Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-suggesting-features)
+- [Creating Issues/Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,15 +1,15 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues & Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-issues-&-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)
 - [Testing Your Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#testing-your-code)
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
-- [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#-creating-a-pull-request)
+- [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues & Suggesting Features
+## Creating Issues And Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues/Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues/Suggesting Features
+## Creating Issues And Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues & Suggesting Features
+## Creating Issues/Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-/-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)
@@ -9,7 +9,7 @@
 - [Running the App Locally](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#running-the-app-locally)
 - [Creating a Pull Request](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-pull-request)
 
-## Creating Issues / Suggesting Features
+## Creating Issues/Suggesting Features
 
 Navigate to the [GitHub repository issues page](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues) and click the "New Issue" button.
 

--- a/docs/ContributorGuide.md
+++ b/docs/ContributorGuide.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Table of Contents
-- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
+- [Creating Issues And Suggesting Features](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/%2361-eshwari/docs/ContributorGuide.md#creating-issues-and-suggesting-features)
 - [Creating a Branch](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-branch)
 - [Writing Code](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#writing-code)
 - [Creating a Commit](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md#creating-a-commit)


### PR DESCRIPTION
Closes #61 
1. About page had link to Docs vs docs
2. Contributor guide had broken links for 1st and last item
3. For the 1st item I think that & symbols are weird in links to section headers so changed it to an actual word