### PR TITLE
Created Projects Detail Page to Display WBS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
-  "name": "pm-site-netlify",
+  "name": "ner-pm-dashboard-v2",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pm-site-netlify",
-      "version": "0.1.0",
+      "name": "ner-pm-dashboard-v2",
       "hasInstallScript": true,
-      "license": "ISC",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@octokit/core": "^3.2.5",
         "@prisma/client": "^2.16.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
       "docs",
       "lambda",
       "node_modules",
-      "public"
+      "public",
+      "lib"
     ]
   },
   "prettier": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import React from 'react';
 import { BrowserRouter, Switch, Route, Link } from 'react-router-dom';
 import ChangeRequests from './pages/change-requests/change-requests';
 import Projects from './pages/projects/projects';
@@ -24,12 +23,8 @@ function App() {
         </Link>
       </nav>
       <Switch>
-        <Route path="/projects">
-          <Projects />
-        </Route>
-        <Route path="/change-requests">
-          <ChangeRequests />
-        </Route>
+        <Route path="/projects" component={Projects} />
+        <Route path="/change-requests" component={ChangeRequests} />
         <Route path="/">
           <h3>Home!</h3>
         </Route>

--- a/src/containers/projects-table/projects-table.test.tsx
+++ b/src/containers/projects-table/projects-table.test.tsx
@@ -6,8 +6,9 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import ProjectsTable from './projects-table';
+import { wbsRegex } from '../../shared/test-utils';
 import { Project } from 'utils';
+import ProjectsTable from './projects-table';
 
 // Build example test data
 const exampleProject1: Project = {
@@ -59,7 +60,6 @@ const exampleAllProjects: Project[] = [
 ];
 
 const endpointURL: string = '/.netlify/functions/projects';
-const wbsRegex: RegExp = /[1-2]\.([1-9]{1}([0-9]{1})?)\.[0-9]{1,2}/;
 
 // Mock the server endpoint(s) that the component will hit
 const server = setupServer(

--- a/src/containers/projects-table/projects-table.tsx
+++ b/src/containers/projects-table/projects-table.tsx
@@ -3,13 +3,14 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { AxiosResponse } from 'axios';
 import { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import BootstrapTable, {
   ColumnDescription,
   RowEventHandlerProps,
   SortOrder
 } from 'react-bootstrap-table-next';
+import { AxiosResponse } from 'axios';
 import { Project } from 'utils';
 import { apiFetch } from '../../shared/axios';
 import styles from './projects-table.module.css';
@@ -18,6 +19,7 @@ import styles from './projects-table.module.css';
  * Interactive table for fetching and displaying all projects data.
  */
 const ProjectsTable: React.FC = () => {
+  const history = useHistory();
   const initial: Project[] = [];
   const [allProjects, setAllProjects] = useState(initial); // store projects data
 
@@ -69,7 +71,7 @@ const ProjectsTable: React.FC = () => {
   // define what happens during various row events
   const rowEvents: RowEventHandlerProps = {
     onClick: (e, row, rowIndex) => {
-      alert(`You clicked on row ${row.wbsNum}!`);
+      history.push(`/projects/${row.wbsNum}`);
     }
   };
 

--- a/src/pages/projects/projects.test.tsx
+++ b/src/pages/projects/projects.test.tsx
@@ -3,11 +3,109 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { Project } from 'utils';
+import { renderWithRouter } from '../../shared/test-utils';
 import Projects from './projects';
 
-test('Renders title', () => {
-  render(<Projects />);
-  const titleElement = screen.getByText(/Projects Page/i);
-  expect(titleElement).toBeInTheDocument();
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent: Function = (routeOverride: string) => {
+  const renderRoute: string = routeOverride || '/projects';
+  renderWithRouter(Projects, { route: renderRoute });
+};
+
+// Build example test data
+const exampleProject1: Project = {
+  wbsNum: '1.1.0',
+  name: 'Impact Attenuator',
+  projectLead: 'Person Allen',
+  projectManager: 'Person Gilbert',
+  duration: 2
+};
+
+const exampleProject2: Project = {
+  wbsNum: '1.2.0',
+  name: 'Bodywork',
+  projectLead: 'Person Richard',
+  projectManager: 'Person David',
+  duration: 4
+};
+
+const exampleProject3: Project = {
+  wbsNum: '1.12.0',
+  name: 'Battery Box',
+  projectLead: 'Person Karen',
+  projectManager: 'Person Solomon',
+  duration: 3
+};
+
+const exampleProject4: Project = {
+  wbsNum: '2.6.0',
+  name: 'Motor Controller Integration',
+  projectLead: 'Person Emily',
+  projectManager: 'Person Zoe',
+  duration: 9
+};
+
+const exampleProject5: Project = {
+  wbsNum: '2.8.0',
+  name: 'Driver IO',
+  projectLead: 'Person George',
+  projectManager: 'Person William',
+  duration: 12
+};
+
+const exampleAllProjects: Project[] = [
+  exampleProject1,
+  exampleProject2,
+  exampleProject3,
+  exampleProject4,
+  exampleProject5
+];
+
+const endpointURL: string = '/.netlify/functions/projects';
+
+// Mock the server endpoint(s) that the component will hit
+const server = setupServer(
+  rest.get(endpointURL, (req, res, ctx) => {
+    return res(ctx.json(exampleAllProjects));
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('projects page component', () => {
+  test('renders the page title', () => {
+    renderComponent();
+    expect(screen.getByText(/Projects Page/i)).toBeInTheDocument();
+  });
+
+  test('renders the projects table page title', () => {
+    renderComponent();
+    expect(screen.getByText(/Projects Table/i)).toBeInTheDocument();
+  });
+
+  test('renders the wbs element number title', () => {
+    const wbsNumToRender: string = '1.8.1';
+    renderComponent(`/projects/${wbsNumToRender}`);
+    expect(screen.getByText(wbsNumToRender, { exact: false })).toBeInTheDocument();
+  });
+
+  test('renders 1.1.0 as a project', () => {
+    const wbsNumToRender: string = '1.1.0';
+    renderComponent(`/projects/${wbsNumToRender}`);
+    expect(screen.getByText(`Project ${wbsNumToRender}`)).toBeInTheDocument();
+  });
+
+  test('renders 2.18.7 as a work package', () => {
+    const wbsNumToRender: string = '2.18.7';
+    renderComponent(`/projects/${wbsNumToRender}`);
+    expect(screen.getByText(`Work Package ${wbsNumToRender}`)).toBeInTheDocument();
+  });
 });

--- a/src/pages/projects/projects.tsx
+++ b/src/pages/projects/projects.tsx
@@ -3,14 +3,19 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { Route, Switch } from 'react-router-dom';
 import ProjectsTable from '../../containers/projects-table/projects-table';
+import WBSDetails from '../wbs-details/wbs-details';
 import './projects.module.css';
 
 const Projects: React.FC = () => {
   return (
     <div>
       <h1>This is the Projects Page</h1>
-      <ProjectsTable />
+      <Switch>
+        <Route path="/projects/:wbsNum" component={WBSDetails} />
+        <Route path="/projects" component={ProjectsTable} />
+      </Switch>
     </div>
   );
 };

--- a/src/pages/wbs-details/wbs-details.module.css
+++ b/src/pages/wbs-details/wbs-details.module.css
@@ -1,0 +1,9 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+.describe {
+  font-size: 12;
+  color: black;
+}

--- a/src/pages/wbs-details/wbs-details.test.tsx
+++ b/src/pages/wbs-details/wbs-details.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { screen } from '@testing-library/react';
+import { renderWithRouter } from '../../shared/test-utils';
+import WBSDetails from './wbs-details';
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ *
+ * @param options WBS number to render the component at
+ */
+const renderComponent: Function = (wbsOverride: string) => {
+  const wbsNumber: string = wbsOverride || '1.1.1';
+  renderWithRouter(WBSDetails, { path: '/projects/:wbsNum', route: `/projects/${wbsNumber}` });
+};
+
+describe('wbs element details component', () => {
+  test('renders the page title', () => {
+    renderComponent();
+    expect(screen.getByText(/WBS Page/i)).toBeInTheDocument();
+  });
+
+  test('renders the wbs element number title', () => {
+    const wbsNumToRender: string = '1.8.1';
+    renderComponent(wbsNumToRender);
+    expect(screen.getByText(wbsNumToRender, { exact: false })).toBeInTheDocument();
+  });
+
+  test('renders 1.1.0 as a project', () => {
+    const wbsNumToRender: string = '1.1.0';
+    renderComponent(wbsNumToRender);
+    expect(screen.getByText(`Project ${wbsNumToRender}`)).toBeInTheDocument();
+  });
+
+  test('renders 2.18.7 as a work package', () => {
+    const wbsNumToRender: string = '2.18.7';
+    renderComponent(wbsNumToRender);
+    expect(screen.getByText(`Work Package ${wbsNumToRender}`)).toBeInTheDocument();
+  });
+});

--- a/src/pages/wbs-details/wbs-details.tsx
+++ b/src/pages/wbs-details/wbs-details.tsx
@@ -1,0 +1,29 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useParams } from 'react-router-dom';
+import { validateWBS, wbsIsProject } from 'utils';
+import styles from './wbs-details.module.css';
+
+const WBSDetails: React.FC = () => {
+  interface ParamTypes {
+    wbsNum: string;
+  }
+  const { wbsNum } = useParams<ParamTypes>();
+
+  validateWBS(wbsNum); // ensure the provided wbsNum is correctly formatted
+
+  const type: string = wbsIsProject(wbsNum) ? 'Project' : 'Work Package';
+  return (
+    <div>
+      <h2>This is the WBS Page</h2>
+      <p className={styles.describe}>
+        {type} {wbsNum}
+      </p>
+    </div>
+  );
+};
+
+export default WBSDetails;

--- a/src/shared/test-utils.tsx
+++ b/src/shared/test-utils.tsx
@@ -1,0 +1,26 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+// Regular Expression to match WBS Numbers
+export const wbsRegex: RegExp = /[1-2]\.([1-9]{1}([0-9]{1})?)\.[0-9]{1,2}/;
+
+/**
+ * Render a React component wrapped in a memory router for testing.
+ *
+ * @param ui React component under test
+ * @param options Path to place component and route to navigate to (both optional)
+ */
+export const renderWithRouter = (ui: React.FC, { path = '/', route = '/' }) => {
+  const toRender: ReactElement = (
+    <MemoryRouter initialEntries={[route]}>
+      <Route path={path} component={ui} />
+    </MemoryRouter>
+  );
+  render(toRender);
+};

--- a/src/utils/package-lock.json
+++ b/src/utils/package-lock.json
@@ -1,8 +1,142 @@
 {
   "name": "utils",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.1.0",
+      "license": "AGPL-v3.0",
+      "dependencies": {
+        "rimraf": "^3.0.2",
+        "typescript": "^4.1.3"
+      },
+      "devDependencies": {
+        "prettier": "^2.2.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  },
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",

--- a/src/utils/package.json
+++ b/src/utils/package.json
@@ -30,7 +30,8 @@
       "docs",
       "lambda",
       "node_modules",
-      "public"
+      "public",
+      "lib"
     ]
   },
   "prettier": {

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -6,3 +6,4 @@
 export * from './example-shared';
 export * from './types/change-request-types';
 export * from './types/project-types';
+export * from './validate-wbs';

--- a/src/utils/src/validate-wbs.ts
+++ b/src/utils/src/validate-wbs.ts
@@ -1,0 +1,37 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+/**
+ * Ensure the provided wbsNum is a valid Work Breakdown Structure Number
+ *
+ * @param wbsNum WBS number to validate
+ */
+export const validateWBS: Function = (wbsNum: string): void => {
+  const errorMsg: string = 'WBS Invalid: ';
+  if (wbsNum == null || wbsNum === undefined) {
+    throw new Error(errorMsg + 'given WBS # is null');
+  }
+  if (wbsNum.match(/\./g) == null) {
+    throw new Error(errorMsg + 'WBS #s include periods, none found');
+  }
+  const wbsArr: string[] = wbsNum.split('.');
+  if (wbsArr.length !== 3) {
+    throw new Error(errorMsg + 'incorrect number of periods');
+  }
+  if (wbsArr[0] !== '1' && wbsArr[0] !== '2') {
+    throw new Error(errorMsg + 'functional areas are only 1 or 2, found ' + wbsArr[0]);
+  }
+};
+
+/**
+ * Is the provided wbsNum a project?
+ *
+ * @param wbsNum WBS number to check
+ */
+export const wbsIsProject: Function = (wbsNum: string): boolean => {
+  validateWBS(wbsNum);
+  const splitWBS: string[] = wbsNum.split('.');
+  return splitWBS[2] === '0';
+};

--- a/src/utils/tests/validate-wbs.test.ts
+++ b/src/utils/tests/validate-wbs.test.ts
@@ -1,0 +1,83 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { validateWBS, wbsIsProject } from '../src/validate-wbs';
+
+describe('validate wbs numbers', () => {
+  it('does not throw on valid WBS nums', () => {
+    const validWbsNums: string[] = [
+      '1.1.1',
+      '1.1.0',
+      '1.10.1',
+      '1.10.10',
+      '1.6.15',
+      '2.1.1',
+      '2.3.0',
+      '2.54.1',
+      '2.16.9',
+      '2.2.36'
+    ];
+    validWbsNums.forEach((wbs) => expect(() => validateWBS(wbs)).not.toThrow());
+  });
+
+  it('throws if no periods', () => {
+    expect(() => {
+      validateWBS('11');
+    }).toThrowError('WBS Invalid: WBS #s include periods, none found');
+  });
+
+  it('throws if only 1 period', () => {
+    expect(() => {
+      validateWBS('1.1');
+    }).toThrowError('WBS Invalid: incorrect number of periods');
+  });
+
+  it('throws if greater than 2 periods', () => {
+    const expectedError: string = 'WBS Invalid: incorrect number of periods';
+    expect(() => validateWBS('1.1.1.')).toThrowError(expectedError);
+    expect(() => validateWBS('1.1.1..')).toThrowError(expectedError);
+    expect(() => validateWBS('1.1.1.1.1.1')).toThrowError(expectedError);
+  });
+
+  it('throws if functional area not 1 or 2', () => {
+    const expectedError: string = 'WBS Invalid: functional areas are only 1 or 2, found ';
+    expect(() => validateWBS('3.1.1')).toThrowError(expectedError + '3');
+    expect(() => validateWBS('X.1.1')).toThrowError(expectedError + 'X');
+    expect(() => validateWBS('<.1.1')).toThrowError(expectedError + '<');
+  });
+});
+
+describe('check wbs numbers are projects', () => {
+  it('does not throw on valid WBS nums', () => {
+    const validWbsNums: string[] = ['1.1.1', '1.10.10', '1.6.15', '2.54.1', '2.2.36'];
+    validWbsNums.forEach((wbs) => expect(() => wbsIsProject(wbs)).not.toThrow());
+  });
+
+  it('throws if no periods', () => {
+    expect(() => {
+      validateWBS('11');
+    }).toThrowError('WBS Invalid: WBS #s include periods, none found');
+  });
+
+  it('throws if only 1 period', () => {
+    expect(() => {
+      validateWBS('1.1');
+    }).toThrowError('WBS Invalid: incorrect number of periods');
+  });
+
+  it('throws if greater than 2 periods', () => {
+    const expectedError: string = 'WBS Invalid: incorrect number of periods';
+    expect(() => validateWBS('1.1.1.')).toThrowError(expectedError);
+    expect(() => validateWBS('1.1.1..')).toThrowError(expectedError);
+    expect(() => validateWBS('1.1.1.1.1.1')).toThrowError(expectedError);
+  });
+
+  it('throws if functional area not 1 or 2', () => {
+    const expectedError: string = 'WBS Invalid: functional areas are only 1 or 2, found ';
+    expect(() => validateWBS('3.1.1')).toThrowError(expectedError + '3');
+    expect(() => validateWBS('X.1.1')).toThrowError(expectedError + 'X');
+    expect(() => validateWBS('<.1.1')).toThrowError(expectedError + '<');
+  });
+});


### PR DESCRIPTION
Created a new page that will display either project details or work package details when given the WBS number. Reconfigured various different shared code, added WBS number validation from v1 repo, and the routing wiring to accommodate this new change. This change results in being able to click on rows in the projects table and be navigated to a page to see the details for the desired WBS number.

Projects table:
<img width="1482" alt="Screen Shot 2021-02-27 at 1 51 14 AM" src="https://user-images.githubusercontent.com/51571627/109383869-47d15880-789e-11eb-9b9e-7dfd55dd1869.png">

Navigated via click on row:
<img width="637" alt="Screen Shot 2021-02-27 at 1 51 25 AM" src="https://user-images.githubusercontent.com/51571627/109383874-4dc73980-789e-11eb-9f87-943f637dbff1.png">

Navigated via direct URL navigation:
<img width="457" alt="Screen Shot 2021-02-27 at 1 52 28 AM" src="https://user-images.githubusercontent.com/51571627/109383904-74857000-789e-11eb-8e02-ba67c0f9e25d.png">
