### PR TITLE
Created change request page and table page

### DIFF
--- a/src/components/change-request-details/change-request-details.module.css
+++ b/src/components/change-request-details/change-request-details.module.css
@@ -10,7 +10,6 @@
   border-width: thin;
   border-radius: 1em;
   width: fit-content;
-  margin: 0em 10em 0em 10em;
   padding: 25px;
 }
 

--- a/src/components/change-request-details/change-request-details.tsx
+++ b/src/components/change-request-details/change-request-details.tsx
@@ -128,7 +128,7 @@ const ChangeRequestDetails: React.FC<ChangeRequestDetailsProps> = ({
   changeRequest
 }: ChangeRequestDetailsProps) => {
   return (
-    <div className={styles.boundingBox}>
+    <div className={`mx-auto ${styles.boundingBox}`}>
       <h4 className={styles.title}>Change Request #{changeRequest.id}</h4>
       <div className="container">
         <dl className="row">

--- a/src/components/change-requests-table/change-requests-table.module.css
+++ b/src/components/change-requests-table/change-requests-table.module.css
@@ -1,0 +1,8 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+.table {
+  padding: 0em 2em 0em 2em;
+}

--- a/src/components/change-requests-table/change-requests-table.test.tsx
+++ b/src/components/change-requests-table/change-requests-table.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { ChangeRequest, exampleAllChangeRequests } from 'utils';
+import { booleanPipe, fullNamePipe, wbsPipe } from '../../shared/pipes';
+import ChangeRequestsTable, { DisplayChangeRequest } from './change-requests-table';
+
+// Sets up the component under test with the desired values and renders it.
+const renderComponent: (changeRequests?: DisplayChangeRequest[]) => void = (crs) => {
+  if (!crs) {
+    crs = exampleAllChangeRequests.map((cr: ChangeRequest) => {
+      return {
+        id: cr.id,
+        submitterName: fullNamePipe(cr.submitter),
+        wbsNum: wbsPipe(cr.wbsNum),
+        type: cr.type,
+        dateReviewed: cr.dateReviewed ? cr.dateReviewed.toLocaleDateString() : '',
+        accepted: cr.accepted ? booleanPipe(cr.accepted) : '',
+        dateImplemented: cr.dateImplemented ? cr.dateImplemented.toLocaleDateString() : ''
+      };
+    });
+  }
+  render(<ChangeRequestsTable changeRequests={crs!} />);
+};
+
+describe('change requests table view component', () => {
+  it('renders the table headers', async () => {
+    renderComponent([]);
+
+    expect(screen.getByText(/ID/i)).toBeInTheDocument();
+    expect(screen.getByText(/Submitter/i)).toBeInTheDocument();
+    expect(screen.getByText(/WBS #/i)).toBeInTheDocument();
+    expect(screen.getByText(/Type/i)).toBeInTheDocument();
+    expect(screen.getByText(/Accepted/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/change-requests-table/change-requests-table.tsx
+++ b/src/components/change-requests-table/change-requests-table.tsx
@@ -1,0 +1,78 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useHistory } from 'react-router-dom';
+import BootstrapTable, {
+  ColumnDescription,
+  RowEventHandlerProps,
+  SortOrder
+} from 'react-bootstrap-table-next';
+import styles from './change-requests-table.module.css';
+
+export interface DisplayChangeRequest {
+  id: number;
+  submitterName: string;
+  wbsNum: string;
+  type: string;
+  dateReviewed: string;
+  accepted: string;
+  dateImplemented: string;
+}
+
+interface ChangeRequestsTableProps {
+  changeRequests: DisplayChangeRequest[];
+}
+
+/**
+ * Interactive table for displaying all change request data.
+ */
+const ChangeRequestsTable: React.FC<ChangeRequestsTableProps> = ({
+  changeRequests
+}: ChangeRequestsTableProps) => {
+  const history = useHistory();
+
+  // Configures display options for all data columns
+  const columns: ColumnDescription[] = [
+    { dataField: 'id', text: 'ID', align: 'center', sort: true },
+    { dataField: 'submitterName', text: 'Submitter', align: 'left', sort: true },
+    { dataField: 'wbsNum', text: 'WBS #', align: 'left', sort: true },
+    { dataField: 'type', text: 'Type', align: 'left', sort: true },
+    { dataField: 'dateReviewed', text: 'Reviewed', align: 'left', sort: true },
+    { dataField: 'accepted', text: 'Accepted', align: 'center', sort: true },
+    { dataField: 'dateImplemented', text: 'Implemented', align: 'left', sort: true }
+  ];
+
+  const defaultSort: [{ dataField: any; order: SortOrder }] = [
+    {
+      dataField: 'id',
+      order: 'asc'
+    }
+  ];
+
+  // define what happens during various row events
+  const rowEvents: RowEventHandlerProps = {
+    onClick: (e, row, rowIndex) => {
+      history.push(`/change-requests/${row.id}`);
+    }
+  };
+
+  return (
+    <BootstrapTable
+      striped
+      hover
+      condensed
+      wrapperClasses={styles.table}
+      bootstrap4={true}
+      keyField="id"
+      data={changeRequests}
+      columns={columns}
+      defaultSorted={defaultSort}
+      rowEvents={rowEvents}
+      noDataIndication="No Change Requests to Display"
+    />
+  );
+};
+
+export default ChangeRequestsTable;

--- a/src/containers/change-requests-table/change-requests-table.module.css
+++ b/src/containers/change-requests-table/change-requests-table.module.css
@@ -2,7 +2,3 @@
  * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-
-.label {
-  color: brown;
-}

--- a/src/containers/change-requests-table/change-requests-table.test.tsx
+++ b/src/containers/change-requests-table/change-requests-table.test.tsx
@@ -3,11 +3,49 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
 import { render, screen } from '@testing-library/react';
+import { exampleAllChangeRequests } from 'utils';
 import ChangeRequestsTable from './change-requests-table';
 
-test('Renders title', () => {
+const endpointURL: string = '/.netlify/functions/change-requests';
+
+// Mock the server endpoint(s) that the component will hit
+const server = setupServer(
+  rest.get(endpointURL, (req, res, ctx) => {
+    return res(ctx.json(exampleAllChangeRequests));
+  })
+);
+
+// Sets up the component under test with the desired values and renders it.
+const renderComponent: () => void = () => {
   render(<ChangeRequestsTable />);
-  const titleElement = screen.getByText(/Change Requests Table/i);
-  expect(titleElement).toBeInTheDocument();
+};
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('change requests table container', () => {
+  it('renders the table headers', async () => {
+    renderComponent();
+    expect(screen.getByText(/ID/i)).toBeInTheDocument();
+    expect(screen.getByText(/Submitter/i)).toBeInTheDocument();
+    expect(screen.getByText(/WBS #/i)).toBeInTheDocument();
+    expect(screen.getByText(/Type/i)).toBeInTheDocument();
+    expect(screen.getByText(/Accepted/i)).toBeInTheDocument();
+  });
+
+  it('handles the api throwing an error', async () => {
+    server.use(
+      rest.get(endpointURL, (req, res, ctx) => {
+        return res(ctx.status(500));
+      })
+    );
+
+    renderComponent();
+
+    expect(screen.getByText(/No Change Requests to Display/i)).toBeInTheDocument();
+  });
 });

--- a/src/containers/change-requests-table/change-requests-table.tsx
+++ b/src/containers/change-requests-table/change-requests-table.tsx
@@ -3,35 +3,58 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { useState } from 'react';
-import { ChangeRequest, exampleAllChangeRequests } from 'utils';
-import ChangeRequestDetails from '../../components/change-request-details/change-request-details';
-import styles from './change-requests-table.module.css';
+import { useEffect, useState } from 'react';
+import { AxiosResponse } from 'axios';
+import { ChangeRequest } from 'utils';
+import { apiFetch } from '../../shared/axios';
+import { booleanPipe, fullNamePipe, wbsPipe } from '../../shared/pipes';
+import CRTable from '../../components/change-requests-table/change-requests-table'; // Directly rename the default import
+import { DisplayChangeRequest } from '../../components/change-requests-table/change-requests-table';
+import './change-requests-table.module.css';
 
 const ChangeRequestsTable: React.FC = () => {
-  const crOptions: Array<string> = ['Duration', 'Budget', 'Scope'];
-  const [changeRequestOption, setChangeRequestOption] = useState(0);
+  const [allChangeRequests, setAllChangeRequests] = useState<DisplayChangeRequest[]>([]); // store projects data
 
-  const switchCR = () => {
-    changeRequestOption === 2
-      ? setChangeRequestOption(0)
-      : setChangeRequestOption(changeRequestOption + 1);
+  // Transforms given change request data and sets local state
+  const updateData: (response: AxiosResponse) => void = (res) => {
+    setAllChangeRequests(
+      res.data.map((cr: ChangeRequest) => {
+        return {
+          id: cr.id,
+          submitterName: fullNamePipe(cr.submitter),
+          wbsNum: wbsPipe(cr.wbsNum),
+          type: cr.type,
+          dateReviewed: cr.dateReviewed ? new Date(cr.dateReviewed).toLocaleDateString() : '',
+          accepted: cr.accepted ? booleanPipe(cr.accepted) : '',
+          dateImplemented: cr.dateImplemented
+            ? new Date(cr.dateImplemented).toLocaleDateString()
+            : ''
+        };
+      })
+    );
   };
 
-  return (
-    <div>
-      <h1>This is the Change Requests Table container</h1>
-      <p className={styles.label}>{crOptions[changeRequestOption]}</p>
-      <button onClick={switchCR}>Click me!</button>
-      {exampleAllChangeRequests.map((cr: ChangeRequest, idx: number) => (
-        <div key={idx}>
-          <br />
-          <hr />
-          <ChangeRequestDetails changeRequest={cr} />
-        </div>
-      ))}
-    </div>
-  );
+  // Fetch list of change requests from API on component loading
+  useEffect(() => {
+    let mounted = true; // indicates component is mounted
+
+    const fetchChangeRequests: Function = async () => {
+      apiFetch
+        .get('/change-requests')
+        .then((response: AxiosResponse) => (mounted ? updateData(response) : ''))
+        .catch((error) =>
+          mounted ? console.log('fetch change requests error: ' + error.message) : ''
+        );
+    };
+    fetchChangeRequests();
+
+    // cleanup function indicates component has been unmounted
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return <CRTable changeRequests={allChangeRequests} />;
 };
 
 export default ChangeRequestsTable;

--- a/src/pages/change-request-details/change-request-details.module.css
+++ b/src/pages/change-request-details/change-request-details.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/pages/change-request-details/change-request-details.test.tsx
+++ b/src/pages/change-request-details/change-request-details.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { screen } from '@testing-library/react';
+import { ChangeRequest, exampleAllChangeRequests } from 'utils';
+import { renderWithRouter } from '../../shared/test-utils';
+import ChangeRequestDetails from './change-request-details';
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ *
+ * @param options WBS number to render the component at
+ */
+const renderComponent: Function = (id: string) => {
+  const idNum: string = id || '1';
+  renderWithRouter(ChangeRequestDetails, {
+    path: '/change-requests/:wbsNum',
+    route: `/change-requests/${idNum}`
+  });
+};
+
+const endpointURL: string = '/.netlify/functions/change-requests/:id';
+
+// Mock the server endpoint(s) that the component will hit
+const server = setupServer(
+  rest.get(endpointURL, (req, res, ctx) => {
+    const result: ChangeRequest | undefined = exampleAllChangeRequests.find(
+      (val) => req.params.id === val.id
+    );
+    if (result === undefined) {
+      res(ctx.status(404, 'Cannot find the requested change request'));
+    }
+    return res(ctx.json(result));
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('wbs element details component', () => {
+  test('renders the page title', () => {
+    renderComponent();
+    expect(screen.getByText(/Change Request/i)).toBeInTheDocument();
+  });
+
+  test('renders the change request id number', () => {
+    const id: string = '37';
+    renderComponent(id);
+    expect(screen.getByText(`#${id}`, { exact: false })).toBeInTheDocument();
+  });
+});

--- a/src/pages/change-request-details/change-request-details.tsx
+++ b/src/pages/change-request-details/change-request-details.tsx
@@ -1,0 +1,54 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { AxiosResponse } from 'axios';
+import { ChangeRequest, exampleStandardChangeRequest } from 'utils';
+import { apiFetch } from '../../shared/axios';
+import ChangeRequestDetailsView from '../../components/change-request-details/change-request-details';
+import './change-request-details.module.css';
+
+const ChangeRequestDetails: React.FC = () => {
+  interface ParamTypes {
+    id: string;
+  }
+  const { id } = useParams<ParamTypes>();
+  const [changeRequest, setChangeRequest] = useState<ChangeRequest>(exampleStandardChangeRequest); // store projects data
+
+  // Transforms given project data and sets local state
+  const updateData: (response: AxiosResponse) => void = (res) => {
+    setChangeRequest({
+      ...res.data,
+      dateSubmitted: new Date(res.data.dateSubmitted),
+      dateReviewed: new Date(res.data.dateReviewed),
+      dateImplemented: new Date(res.data.dateImplemented)
+    });
+  };
+
+  // Fetch change request from API on component loading
+  useEffect(() => {
+    let mounted = true; // indicates component is mounted
+
+    const fetchChangeRequest: Function = async () => {
+      apiFetch
+        .get(`/change-requests/${id}`)
+        .then((response: AxiosResponse) => (mounted ? updateData(response) : ''))
+        .catch((error) =>
+          mounted ? console.log('fetch change request error: ' + error.message) : ''
+        );
+    };
+    fetchChangeRequest();
+
+    // cleanup function indicates component has been unmounted
+    return () => {
+      mounted = false;
+    };
+  }, [id]);
+
+  return <ChangeRequestDetailsView changeRequest={changeRequest} />;
+};
+
+export default ChangeRequestDetails;

--- a/src/pages/change-requests/change-requests.test.tsx
+++ b/src/pages/change-requests/change-requests.test.tsx
@@ -3,11 +3,54 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render, screen } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { screen } from '@testing-library/react';
+import { exampleAllChangeRequests } from 'utils';
+import { renderWithRouter } from '../../shared/test-utils';
 import ChangeRequests from './change-requests';
 
-test('Renders title', () => {
-  render(<ChangeRequests />);
-  const titleElement = screen.getByText(/Change Requests Page/i);
-  expect(titleElement).toBeInTheDocument();
+const endpointURL: string = '/.netlify/functions/change-requests/1';
+
+// Mock the server endpoint(s) that the component will hit
+const server = setupServer(
+  rest.get(endpointURL, (req, res, ctx) => {
+    return res(ctx.json(exampleAllChangeRequests[0]));
+  })
+);
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ *
+ * @param options ID number to render the component at
+ */
+const renderComponent: Function = (idOverride: string) => {
+  const idNum: string = idOverride || '1';
+  renderWithRouter(ChangeRequests, {
+    path: '/change-requests/:id',
+    route: `/change-requests/${idNum}`
+  });
+};
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('change request details component', () => {
+  it('renders the page title', () => {
+    renderComponent();
+    expect(screen.getByText(/Change Requests Page/i)).toBeInTheDocument();
+  });
+
+  it('renders the change request id title', () => {
+    const id: string = '37';
+    renderComponent(id);
+    expect(screen.getByText(id, { exact: false })).toBeInTheDocument();
+  });
+
+  it('renders CR #69 as a project', () => {
+    const id: string = '69';
+    renderComponent(id);
+    expect(screen.getByText(`Design Issue`)).toBeInTheDocument();
+  });
 });

--- a/src/pages/change-requests/change-requests.tsx
+++ b/src/pages/change-requests/change-requests.tsx
@@ -3,14 +3,19 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import styles from './change-requests.module.css';
+import { Route, Switch } from 'react-router-dom';
 import ChangeRequestsTable from '../../containers/change-requests-table/change-requests-table';
+import ChangeRequestDetails from '../change-request-details/change-request-details';
+import styles from './change-requests.module.css';
 
 const ChangeRequests: React.FC = () => {
   return (
     <div>
       <h1 className={styles.title}>This is the Change Requests Page</h1>
-      <ChangeRequestsTable />
+      <Switch>
+        <Route path="/change-requests/:id" component={ChangeRequestDetails} />
+        <Route path="/change-requests" component={ChangeRequestsTable} />
+      </Switch>
     </div>
   );
 };


### PR DESCRIPTION
Created the page for a single change request by wiring up the existing view component with a wrapper for fetching from the API, then also created the table for change requests to be displayed in, then the API fetching wrapper for that table of CRs, and finally wired together the change request routing pathways to ensure that proper front-end routes go to the proper places. Sorry for such a large PR. Closes #69. Closes #140.