### PR TITLE
Remove body tag and restyle 404 page

### DIFF
--- a/src/pages/page-not-found/page-not-found.module.css
+++ b/src/pages/page-not-found/page-not-found.module.css
@@ -1,11 +1,11 @@
 .page_not_found {
-    text-align: center;
+  text-align: center;
 }
 
-h1 {
-    color: black;
+.title {
+  color: black;
 }
 
-h3 {
-    color: gray;
+.subtitle {
+  color: gray;
 }

--- a/src/pages/page-not-found/page-not-found.tsx
+++ b/src/pages/page-not-found/page-not-found.tsx
@@ -2,11 +2,9 @@ import styles from './page-not-found.module.css';
 
 export const PageNotFound: React.FC = () => {
   return (
-    <body>
-      <div className={styles.page_not_found}>
-        <h1>404</h1>
-        <h3>Page not found</h3>
-      </div>
-    </body>
+    <div className={`pt-5 ${styles.page_not_found}`}>
+      <h1 className={styles.title}>404</h1>
+      <h3 className={styles.subtitle}>Page not found</h3>
+    </div>
   );
 };


### PR DESCRIPTION
Removed the body tag from the 404 page not found component. Also went ahead and restyled the component, changed to using class names for CSS styling, and added top padding.

<img width="1484" alt="Screen Shot 2021-04-16 at 9 41 10 AM" src="https://user-images.githubusercontent.com/51571627/115056580-e1c58280-9e97-11eb-844d-38c253853815.png">
