### PR TITLE
Ensure incoming request paths have API path prefix

### DIFF
--- a/src/utils/src/api-utils.ts
+++ b/src/utils/src/api-utils.ts
@@ -5,16 +5,21 @@
 
 import { Context } from 'aws-lambda';
 import { match } from 'path-to-regexp';
+import { API_URL } from './api-routes';
 import { ApiRoute } from './types/api-utils-types';
 
 // Finds the matching route and executes the route's function
 export const routeMatcher: Function = (routes: ApiRoute[], event: any, context: Context) => {
   for (let index = 0; index < routes.length; index += 1) {
     const singleRoute: ApiRoute = routes[index];
-    const matchResults: { params: Object } | false = match(singleRoute.path)(event.path);
+    const requestPath: string = !event.path.startsWith(API_URL) ? API_URL + event.path : event.path;
+    const matchResults: { params: Object } | false = match(singleRoute.path)(requestPath);
     if (matchResults && event.httpMethod === singleRoute.httpMethod) {
       return singleRoute.func(matchResults.params, event, context);
     }
   }
-  return { statusCode: 404, body: 'Could not find a matching route for the request.' };
+  return {
+    statusCode: 404,
+    body: `Could not find a route matching the requested path [${event.path}].`
+  };
 };

--- a/src/utils/src/dummy-data.ts
+++ b/src/utils/src/dummy-data.ts
@@ -16,6 +16,7 @@ import {
 import { User, Role } from './types/user-types';
 import { WbsNumber } from './types/wbs-types';
 import { ApiRoute } from './types/api-utils-types';
+import { API_URL } from './api-routes';
 
 /**
  * A variety of dummy data for use in performing various different tests, mocking components, or serving from the API.
@@ -423,10 +424,10 @@ export const exampleAllChangeRequests: ChangeRequest[] = [
 /********************** API Util Dummy Data **********************/
 
 export const exampleApiRoutes: ApiRoute[] = [
-  { path: '/projects/one', httpMethod: 'GET', func: () => 5 },
-  { path: '/projects/one', httpMethod: 'POST', func: () => 6 },
-  { path: '/projects/two', httpMethod: 'GET', func: () => 7 },
-  { path: '/projects/three', httpMethod: 'GET', func: () => 8 }
+  { path: `${API_URL}/projects/one`, httpMethod: 'GET', func: () => 5 },
+  { path: `${API_URL}/projects/one`, httpMethod: 'POST', func: () => 6 },
+  { path: `${API_URL}/projects/two`, httpMethod: 'GET', func: () => 7 },
+  { path: `${API_URL}/projects/three`, httpMethod: 'GET', func: () => 8 }
 ];
 
 export const mockContext: Context = {

--- a/src/utils/tests/api-utils.test.ts
+++ b/src/utils/tests/api-utils.test.ts
@@ -3,10 +3,21 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { API_URL } from '../src/api-routes';
 import { routeMatcher } from '../src/api-utils';
 import { exampleApiRoutes } from '../src/dummy-data';
 
 describe('Route matcher behavior', () => {
+  it('matches with no prefix', () => {
+    const exampleEvent: any = { path: '/projects/one', httpMethod: 'GET' };
+    expect(routeMatcher(exampleApiRoutes, exampleEvent, {})).toBe(5);
+  });
+
+  it('matches with prefix', () => {
+    const exampleEvent: any = { path: `${API_URL}/projects/one`, httpMethod: 'GET' };
+    expect(routeMatcher(exampleApiRoutes, exampleEvent, {})).toBe(5);
+  });
+
   it('matches to the first route', () => {
     const exampleEvent: any = { path: '/projects/one', httpMethod: 'GET' };
     expect(routeMatcher(exampleApiRoutes, exampleEvent, {})).toBe(5);


### PR DESCRIPTION
- added check in route matcher
  - prepends API_URL if not already prefix
- refined the error message accompanying the 404 to make debugging easier
- closes #172