### PR TITLE
#157 - Created dependencies component

### DIFF
--- a/src/components/work-package-dependencies/work-package-dependencies.module.css
+++ b/src/components/work-package-dependencies/work-package-dependencies.module.css
@@ -1,0 +1,28 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+.wpDepBox {
+  background-color: #f7f7f7;
+  box-shadow: 2px 2px 5px #dddddd;
+  padding: 30px;
+  border: 0.5px solid;
+  border-radius: 5px;
+  overflow: auto;
+}
+
+.header {
+  width: 100%;
+  overflow: auto;
+  margin-bottom: 30px;
+}
+
+.wbsNum {
+  float: left;
+  padding-right: 30px;
+}
+
+b {
+  font-weight: bold;
+}

--- a/src/components/work-package-dependencies/work-package-dependencies.test.tsx
+++ b/src/components/work-package-dependencies/work-package-dependencies.test.tsx
@@ -1,0 +1,21 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render, screen } from '@testing-library/react';
+import WorkPackageDependencies from './work-package-dependencies';
+import { exampleWorkPackage2, WorkPackage } from 'utils';
+import { wbsPipe } from '../../shared/pipes';
+
+describe('Rendering Work Packagae Dependencies Component', () => {
+  test('Rendering example 2', () => {
+    const wp: WorkPackage = exampleWorkPackage2;
+    render(<WorkPackageDependencies workPackage={wp} />);
+    expect(screen.getByText(`Dependencies`)).toBeInTheDocument();
+
+    wp.dependencies.forEach(function (wbs) {
+      expect(screen.getByText(`${wbsPipe(wbs)}`)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/work-package-dependencies/work-package-dependencies.tsx
+++ b/src/components/work-package-dependencies/work-package-dependencies.tsx
@@ -1,0 +1,39 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { WbsNumber, WorkPackage } from 'utils';
+import { wbsPipe, linkPipe } from '../../shared/pipes';
+import styles from './work-package-dependencies.module.css';
+
+interface WorkPackageDependenciesProps {
+  workPackage: WorkPackage;
+  className?: string;
+}
+
+const WorkPackageDependencies: React.FC<WorkPackageDependenciesProps> = ({
+  workPackage,
+  className
+}: WorkPackageDependenciesProps) => {
+  return (
+    <div className={className}>
+      <div className={styles.wpDepBox}>
+        <div className={styles.header}>
+          <h5>
+            <b>Dependencies</b>
+          </h5>
+        </div>
+        <div>
+          {workPackage.dependencies.map((ele: WbsNumber, idx: number) => (
+            <p key={wbsPipe(ele)} className={styles.wbsNum}>
+              {linkPipe(wbsPipe(ele), `/projects/${wbsPipe(workPackage.wbsNum)}`)}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkPackageDependencies;

--- a/src/components/work-package-dependencies/work-package-dependencies.tsx
+++ b/src/components/work-package-dependencies/work-package-dependencies.tsx
@@ -25,7 +25,7 @@ const WorkPackageDependencies: React.FC<WorkPackageDependenciesProps> = ({
           </h5>
         </div>
         <div>
-          {workPackage.dependencies.map((ele: WbsNumber, idx: number) => (
+          {workPackage.dependencies.map((ele: WbsNumber) => (
             <p key={wbsPipe(ele)} className={styles.wbsNum}>
               {linkPipe(wbsPipe(ele), `/projects/${wbsPipe(workPackage.wbsNum)}`)}
             </p>


### PR DESCRIPTION
<img width="842" alt="Screen Shot 2021-04-29 at 2 13 58 PM" src="https://user-images.githubusercontent.com/46872232/116601153-21f51e00-a8f8-11eb-8860-6604455c4d21.png">

The component looks empty but it matches the other ones that were created. I can change the look of it but this what seemed to make the most sense. It is tested and should be ready to go. Closes #157 