### PR TITLE
Enhance plain text login

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
       "!<rootDir>/src/utils/node_modules/",
       "!**/lib/**",
       "!src/**/*.d.ts"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/setupTests.ts"
     ]
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -86,9 +86,6 @@
       "!<rootDir>/src/utils/node_modules/",
       "!**/lib/**",
       "!src/**/*.d.ts"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/src/setupTests.ts"
     ]
   },
   "browserslist": {

--- a/src/app/app-context/app-context.module.css
+++ b/src/app/app-context/app-context.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/app/app-context/app-context.test.tsx
+++ b/src/app/app-context/app-context.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useContext } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import AppContext, { UserContext, UserLogInContext, UserLogOutContext } from './app-context';
+
+describe('app context', () => {
+  it('renders simple text as children', () => {
+    render(<AppContext>hello</AppContext>);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('provides the user and login function to child components', () => {
+    let setupUser = (_a: string) => {};
+    const TestComponent = () => {
+      const user = useContext(UserContext);
+      setupUser = useContext(UserLogInContext);
+      return <p>{user}</p>;
+    };
+    render(
+      <AppContext>
+        <TestComponent />
+      </AppContext>
+    );
+    act(() => setupUser('test-user'));
+    expect(screen.getByText('test-user')).toBeInTheDocument();
+  });
+
+  it('provides the logout function to child components', () => {
+    let setupUser = (_a: string) => {};
+    const TestComponent = () => {
+      const user = useContext(UserContext);
+      setupUser = useContext(UserLogInContext);
+      const logOutUser = useContext(UserLogOutContext);
+      return (
+        <>
+          <p>{user}</p>
+          <button onClick={logOutUser}>log out</button>
+        </>
+      );
+    };
+    render(
+      <AppContext>
+        <TestComponent />
+      </AppContext>
+    );
+    act(() => setupUser('test-user'));
+    expect(screen.getByText('test-user')).toBeInTheDocument();
+    screen.getByText('log out').click();
+    expect(screen.queryByText('test-user')).not.toBeInTheDocument();
+  });
+
+  it('properly interacts with local storage for log in and log out', () => {
+    let setupUser = (_a: string) => {};
+    const TestComponent = () => {
+      const user = useContext(UserContext);
+      setupUser = useContext(UserLogInContext);
+      const logOutUser = useContext(UserLogOutContext);
+      return (
+        <>
+          <p>{user}</p>
+          <button onClick={logOutUser}>log out</button>
+        </>
+      );
+    };
+    render(
+      <AppContext>
+        <TestComponent />
+      </AppContext>
+    );
+
+    act(() => setupUser('test-user'));
+    expect(localStorage.setItem).toBeCalledTimes(1);
+    expect(localStorage.setItem).toBeCalledWith('userId', 'test-user');
+    expect(screen.getByText('test-user')).toBeInTheDocument();
+
+    screen.getByText('log out').click();
+    expect(localStorage.removeItem).toBeCalledTimes(1);
+    expect(localStorage.removeItem).toBeCalledWith('userId');
+    expect(screen.queryByText('test-user')).not.toBeInTheDocument();
+
+    expect(localStorage.setItem).toBeCalledTimes(1);
+    expect(localStorage.removeItem).toBeCalledTimes(1);
+  });
+});

--- a/src/app/app-context/app-context.tsx
+++ b/src/app/app-context/app-context.tsx
@@ -1,0 +1,37 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { createContext, useState } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import './app-context.module.css';
+
+export const UserContext = createContext<string>('');
+export const UserLogInContext = createContext<(user: string) => void>((u) => '');
+export const UserLogOutContext = createContext<() => void>(() => '');
+
+const AppContext: React.FC = (props) => {
+  const [user, setUser] = useState<string>('');
+
+  const logUserIn = (userName: string) => {
+    setUser(userName);
+    localStorage.setItem('userId', userName);
+  };
+  const logUserOut = () => {
+    setUser('');
+    localStorage.removeItem('userId');
+  };
+
+  return (
+    <UserContext.Provider value={user}>
+      <UserLogInContext.Provider value={logUserIn}>
+        <UserLogOutContext.Provider value={logUserOut}>
+          <BrowserRouter>{props.children}</BrowserRouter>
+        </UserLogOutContext.Provider>
+      </UserLogInContext.Provider>
+    </UserContext.Provider>
+  );
+};
+
+export default AppContext;

--- a/src/app/app-core/app-core.module.css
+++ b/src/app/app-core/app-core.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/app/app-core/app-core.test.tsx
+++ b/src/app/app-core/app-core.test.tsx
@@ -59,13 +59,17 @@ describe('app core', () => {
   });
 
   it('already logged in via memory', () => {
-    renderComponent();
-    act(() => setupUser('test-user'));
+    renderComponent(); // component must render with no mocked setup
+    jest.resetAllMocks(); // reset mocks to get clean slate for testing
+    pushed = []; // reset pushed for clean slate for testing
+    act(() => setupUser('test-user')); // set the user, also triggers re-render
 
-    expect(localStorage.getItem).toBeCalledTimes(4);
+    expect(localStorage.getItem).toBeCalledTimes(2);
     expect(localStorage.getItem).toBeCalledWith('userId');
+    expect(localStorage.setItem).toBeCalledTimes(1);
+    expect(localStorage.setItem).toBeCalledWith('userId', 'test-user');
 
-    expect(pushed).toEqual([routes.LOGIN]);
+    expect(pushed).toEqual([]);
 
     expect(screen.getByText('app public')).toBeInTheDocument();
     expect(screen.getByText('user: test-user')).toBeInTheDocument();
@@ -78,8 +82,10 @@ describe('app core', () => {
 
     expect(localStorage.getItem).toBeCalledTimes(4);
     expect(localStorage.getItem).toBeCalledWith('userId');
+    expect(localStorage.setItem).toBeCalledTimes(1);
+    expect(localStorage.setItem).toBeCalledWith('userId', 'test-user');
 
-    expect(pushed).toEqual([routes.HOME]);
+    expect(pushed).toEqual([]);
 
     expect(screen.getByText('app public')).toBeInTheDocument();
     expect(screen.getByText('user: test-user')).toBeInTheDocument();
@@ -91,6 +97,8 @@ describe('app core', () => {
 
     expect(localStorage.getItem).toBeCalledTimes(2);
     expect(localStorage.getItem).toBeCalledWith('userId');
+    expect(localStorage.setItem).toBeCalledTimes(1);
+    expect(localStorage.setItem).toBeCalledWith('redirectUrl', routes.LOGIN);
 
     expect(pushed).toEqual([routes.LOGIN]);
 

--- a/src/app/app-core/app-core.test.tsx
+++ b/src/app/app-core/app-core.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useContext } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, useHistory } from 'react-router-dom';
+import AppContext, { UserContext, UserLogInContext } from '../app-context/app-context';
+import AppCore from './app-core';
+import { routes } from '../../shared/routes';
+
+jest.mock('../app-public/app-public', () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <div>app public</div>;
+    }
+  };
+});
+
+const mockedLocalStorageGetItem = localStorage.getItem as jest.Mock;
+let setupUser = (_a: string) => {};
+let pushed: string[] = [];
+
+const TestComponent = () => {
+  setupUser = useContext(UserLogInContext);
+  const user = useContext(UserContext);
+  const storedUserId = localStorage.getItem('userId');
+  const history = useHistory();
+  history.listen((loc) => {
+    pushed.push(loc.pathname);
+  });
+  return (
+    <>
+      <p>user: {user}</p>
+      <p>stored user: {storedUserId}</p>
+    </>
+  );
+};
+
+// Sets up the component under test with the desired values and renders it
+const renderComponent = () => {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Route path={'/'}>
+        <AppContext>
+          <AppCore />
+          <TestComponent />
+        </AppContext>
+      </Route>
+    </MemoryRouter>
+  );
+};
+
+describe('app core', () => {
+  afterEach(() => {
+    pushed = [];
+  });
+
+  it('already logged in via memory', () => {
+    renderComponent();
+    act(() => setupUser('test-user'));
+
+    expect(localStorage.getItem).toBeCalledTimes(4);
+    expect(localStorage.getItem).toBeCalledWith('userId');
+
+    expect(pushed).toEqual([routes.LOGIN]);
+
+    expect(screen.getByText('app public')).toBeInTheDocument();
+    expect(screen.getByText('user: test-user')).toBeInTheDocument();
+    expect(screen.getByText('stored user:')).toBeInTheDocument();
+  });
+
+  it('user id is in the local storage', () => {
+    mockedLocalStorageGetItem.mockReturnValue('test-user');
+    renderComponent();
+
+    expect(localStorage.getItem).toBeCalledTimes(4);
+    expect(localStorage.getItem).toBeCalledWith('userId');
+
+    expect(pushed).toEqual([routes.HOME]);
+
+    expect(screen.getByText('app public')).toBeInTheDocument();
+    expect(screen.getByText('user: test-user')).toBeInTheDocument();
+    expect(screen.getByText('stored user: test-user')).toBeInTheDocument();
+  });
+
+  it('no stored user', () => {
+    renderComponent();
+
+    expect(localStorage.getItem).toBeCalledTimes(2);
+    expect(localStorage.getItem).toBeCalledWith('userId');
+
+    expect(pushed).toEqual([routes.LOGIN]);
+
+    expect(screen.getByText('app public')).toBeInTheDocument();
+    expect(screen.getByText('user:')).toBeInTheDocument();
+    expect(screen.getByText('stored user:')).toBeInTheDocument();
+  });
+});

--- a/src/app/app-core/app-core.tsx
+++ b/src/app/app-core/app-core.tsx
@@ -19,11 +19,13 @@ const AppCore: React.FC = () => {
   const storedUserId = localStorage.getItem('userId');
 
   useEffect(() => {
-    if (user === '' && !storedUserId) {
-      history.push(routes.LOGIN);
-    } else if (user === '' && storedUserId) {
+    if (user !== '') {
+      return;
+    } else if (storedUserId) {
       userLogIn(storedUserId);
-      history.push(routes.HOME);
+    } else {
+      localStorage.setItem('redirectUrl', history.location.pathname);
+      history.push(routes.LOGIN);
     }
   }, [user, history, storedUserId, userLogIn]);
 

--- a/src/app/app-core/app-core.tsx
+++ b/src/app/app-core/app-core.tsx
@@ -1,0 +1,33 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useContext, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import { routes } from '../../shared/routes';
+import { UserContext, UserLogInContext } from '../app-context/app-context';
+import AppPublic from '../app-public/app-public';
+import './app-core.module.css';
+
+const AppCore: React.FC = () => {
+  const history = useHistory();
+
+  const user = useContext(UserContext);
+  const userLogIn = useContext(UserLogInContext);
+
+  const storedUserId = localStorage.getItem('userId');
+
+  useEffect(() => {
+    if (user === '' && !storedUserId) {
+      history.push(routes.LOGIN);
+    } else if (user === '' && storedUserId) {
+      userLogIn(storedUserId);
+      history.push(routes.HOME);
+    }
+  }, [user, history, storedUserId, userLogIn]);
+
+  return <AppPublic />;
+};
+
+export default AppCore;

--- a/src/app/app-main/app-main.test.tsx
+++ b/src/app/app-main/app-main.test.tsx
@@ -3,30 +3,42 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../test-support/test-utils';
 import AppMain from './app-main';
+
+jest.mock('../app-core/app-core', () => {
+  return {
+    __esModule: true,
+    default: () => <div>core</div>
+  };
+});
+
+jest.mock('../app-context/app-context', () => {
+  return {
+    __esModule: true,
+    default: (props: any) => (
+      <div>
+        context
+        <div>{props.children}</div>
+      </div>
+    )
+  };
+});
 
 // Sets up the component under test with the desired values and renders it
 const renderComponent: Function = (path?: string, route?: string) => {
   renderWithRouter(AppMain, { path, route });
 };
 
-describe('app main', () => {
-  it('renders login page', () => {
+describe('app main, entry component', () => {
+  it('renders the app context component', () => {
     renderComponent();
-    expect(screen.getByText('NER PM Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Login Required')).toBeInTheDocument();
-    expect(screen.getByText('Log In')).toBeInTheDocument();
+    expect(screen.getByText('context')).toBeInTheDocument();
   });
 
-  it('can login to the application', () => {
+  it('renders the app core component', () => {
     renderComponent();
-    const input: HTMLElement = screen.getByLabelText('name');
-    expect(input).toBeInTheDocument();
-    fireEvent.change(input, { target: { value: 'person' } });
-    fireEvent.click(screen.getByText('Log In'));
-    expect(input).not.toBeInTheDocument();
-    expect(screen.getByText(/Home!/i)).toBeInTheDocument();
+    expect(screen.getByText('core')).toBeInTheDocument();
   });
 });

--- a/src/app/app-main/app-main.tsx
+++ b/src/app/app-main/app-main.tsx
@@ -3,37 +3,15 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { ReactElement, createContext, useState } from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import AppAuthenticated from '../app-authenticated/app-authenticated';
-import AppPublic from '../app-public/app-public';
+import AppContext from '../app-context/app-context';
+import AppCore from '../app-core/app-core';
 import './app-main.module.css';
 
-export const UserContext = createContext<string>('');
-export const UserLogInContext = createContext<(user: string) => void>((u) => '');
-export const UserLogOutContext = createContext<() => void>(() => '');
-
 const AppMain: React.FC = () => {
-  const [user, setUser] = useState<string>('');
-
-  const logUserIn = (userName: string) => setUser(userName);
-
-  const logUserOut = () => setUser('');
-
-  let app: ReactElement = <AppPublic />;
-
-  if (user !== '') {
-    app = <AppAuthenticated />;
-  }
-
   return (
-    <UserContext.Provider value={user}>
-      <UserLogInContext.Provider value={logUserIn}>
-        <UserLogOutContext.Provider value={logUserOut}>
-          <BrowserRouter>{app}</BrowserRouter>
-        </UserLogOutContext.Provider>
-      </UserLogInContext.Provider>
-    </UserContext.Provider>
+    <AppContext>
+      <AppCore />
+    </AppContext>
   );
 };
 

--- a/src/app/app-public/app-public.test.tsx
+++ b/src/app/app-public/app-public.test.tsx
@@ -5,19 +5,31 @@
 
 import { screen } from '@testing-library/react';
 import { renderWithRouter } from '../../test-support/test-utils';
+import { routes } from '../../shared/routes';
 import AppPublic from './app-public';
 
 // Sets up the component under test with the desired values and renders it
-const renderComponent: Function = (path?: string, route?: string) => {
+const renderComponent = (path?: string, route?: string) => {
   renderWithRouter(AppPublic, { path, route });
 };
 
 describe('app public section', () => {
   it('renders login page', () => {
-    renderComponent();
+    renderComponent(routes.LOGIN, routes.LOGIN);
     expect(screen.getByText('NER PM Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Login Required')).toBeInTheDocument();
     expect(screen.getByText('Log In')).toBeInTheDocument();
     expect(screen.getByLabelText('name')).toBeInTheDocument();
+  });
+
+  it('renders app authenticated', () => {
+    renderComponent(routes.PROJECTS, routes.PROJECTS);
+    expect(screen.getByText('NER PM Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+
+    expect(screen.queryByText('Login Required')).not.toBeInTheDocument();
+    expect(screen.queryByText('Log In')).not.toBeInTheDocument();
+    expect(screen.queryByText('name')).not.toBeInTheDocument();
   });
 });

--- a/src/app/app-public/app-public.tsx
+++ b/src/app/app-public/app-public.tsx
@@ -3,15 +3,17 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
+import { routes } from '../../shared/routes';
 import Login from '../../pages/login/login';
+import AppAuthenticated from '../app-authenticated/app-authenticated';
 import './app-public.module.css';
 
 const AppPublic: React.FC = () => {
   return (
     <Switch>
-      <Route path="/login" component={Login} />
-      <Redirect from="*" to="/login" push />
+      <Route path={routes.LOGIN} component={Login} />
+      <Route path="*" component={AppAuthenticated} />
     </Switch>
   );
 };

--- a/src/components/nav-user-menu/nav-user-menu.tsx
+++ b/src/components/nav-user-menu/nav-user-menu.tsx
@@ -8,7 +8,7 @@ import { NavDropdown } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserCircle } from '@fortawesome/free-solid-svg-icons';
-import { UserContext, UserLogOutContext } from '../../app/app-main/app-main';
+import { UserContext, UserLogOutContext } from '../../app/app-context/app-context';
 import './nav-user-menu.module.css';
 
 const NavUserMenu: React.FC = () => {

--- a/src/pages/home/home.test.tsx
+++ b/src/pages/home/home.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import { screen } from '@testing-library/react';
+import { routes } from '../../shared/routes';
 import { renderWithRouter } from '../../test-support/test-utils';
 import Home from './home';
 
@@ -11,7 +12,7 @@ import Home from './home';
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<Home />, { path: '/home', route: `/home` });
+  renderWithRouter(<Home />, { path: routes.HOME, route: routes.HOME });
 };
 
 describe('home component', () => {

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useContext } from 'react';
-import { UserContext } from '../../app/app-main/app-main';
+import { UserContext } from '../../app/app-context/app-context';
 import styles from './home.module.css';
 
 const Home: React.FC = () => {

--- a/src/pages/login/login.test.tsx
+++ b/src/pages/login/login.test.tsx
@@ -23,7 +23,7 @@ const renderComponent = () => {
     });
     return <Login />;
   };
-  renderWithRouter(TestComponent, { path: routes.LOGIN, route: routes.LOGIN });
+  renderWithRouter(<TestComponent />, { path: routes.LOGIN, route: routes.LOGIN });
 };
 
 describe('login component', () => {

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { useContext } from 'react';
 import { useHistory } from 'react-router';
 import { Form, InputGroup, FormControl, Button } from 'react-bootstrap';
-import { UserLogInContext } from '../../app/app-main/app-main';
+import { UserLogInContext } from '../../app/app-context/app-context';
 import styles from './login.module.css';
 
 /**

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -8,6 +8,7 @@ import { useContext } from 'react';
 import { useHistory } from 'react-router';
 import { Form, InputGroup, FormControl, Button } from 'react-bootstrap';
 import { UserLogInContext } from '../../app/app-context/app-context';
+import { routes } from '../../shared/routes';
 import styles from './login.module.css';
 
 /**
@@ -17,13 +18,15 @@ const Login: React.FC = () => {
   const history = useHistory();
   const loginFunc = useContext(UserLogInContext);
   const [userName, setUserName] = useState<string>('');
+  const storedUrl = localStorage.getItem('redirectUrl');
 
   const updateName = (event: any) => setUserName(event.target.value);
 
   const formSubmit = (event: any) => {
     event.preventDefault();
     loginFunc(userName);
-    history.push('/');
+    history.push(storedUrl || routes.HOME);
+    localStorage.removeItem('redirectUrl');
   };
 
   return (

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -8,3 +8,14 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+  key: jest.fn(),
+  length: 0
+};
+
+window.localStorage.__proto__ = localStorageMock;

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -5,6 +5,7 @@
 
 /**************** General Section ****************/
 const HOME: string = `/`;
+const LOGIN: string = `/login`;
 
 /**************** Projects Section ****************/
 const PROJECTS: string = `/projects`;
@@ -17,6 +18,7 @@ const CHANGE_REQUESTS_NEW: string = `${CHANGE_REQUESTS}/new`;
 
 export const routes = {
   HOME,
+  LOGIN,
 
   PROJECTS,
   PROJECTS_BY_WBS,


### PR DESCRIPTION
- added lots of tests
- mock `localStorage` in tests
- split app section so context is separate from login logic
- enabled storage of userId in `localStorage`
- enable storage of page before login for redirect after login
- closes #221