### PR TITLE
#252 - Refactor test utils and implement new wrapping/routing test util patterns

### DIFF
--- a/src/components/app/app-authenticated/app-authenticated.test.tsx
+++ b/src/components/app/app-authenticated/app-authenticated.test.tsx
@@ -3,8 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { fireEvent, screen } from '@testing-library/react';
-import { renderWithRouter } from '../../../test-support/test-utils';
+import { fireEvent, screen, render, routerWrapperBuilder } from '../../../test-support/test-utils';
 import AppAuthenticated from './app-authenticated';
 
 jest.mock('../../projects/projects', () => {
@@ -18,7 +17,12 @@ jest.mock('../../projects/projects', () => {
 
 // Sets up the component under test with the desired values and renders it
 const renderComponent = (path?: string, route?: string) => {
-  renderWithRouter(<AppAuthenticated />, { path, route });
+  const RouterWrapper = routerWrapperBuilder({ path, route });
+  return render(
+    <RouterWrapper>
+      <AppAuthenticated />
+    </RouterWrapper>
+  );
 };
 
 describe('app authenticated section', () => {

--- a/src/components/app/app-context/app-context.test.tsx
+++ b/src/components/app/app-context/app-context.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useContext } from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react'; // avoid circular dependency
 import { useAllChangeRequests } from '../../../services/change-requests.hooks';
 import AppContext, { UserContext, UserLogInContext, UserLogOutContext } from './app-context';
 

--- a/src/components/app/app-context/app-context.tsx
+++ b/src/components/app/app-context/app-context.tsx
@@ -5,7 +5,6 @@
 
 import { createContext, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { BrowserRouter } from 'react-router-dom';
 import './app-context.module.css';
 
 export const UserContext = createContext<string>('');
@@ -30,9 +29,7 @@ const AppContext: React.FC = (props) => {
     <UserContext.Provider value={user}>
       <UserLogInContext.Provider value={logUserIn}>
         <UserLogOutContext.Provider value={logUserOut}>
-          <QueryClientProvider client={queryClient}>
-            <BrowserRouter>{props.children}</BrowserRouter>
-          </QueryClientProvider>
+          <QueryClientProvider client={queryClient}>{props.children}</QueryClientProvider>
         </UserLogOutContext.Provider>
       </UserLogInContext.Provider>
     </UserContext.Provider>

--- a/src/components/app/app-core/app-core.test.tsx
+++ b/src/components/app/app-core/app-core.test.tsx
@@ -4,11 +4,11 @@
  */
 
 import { useContext } from 'react';
-import { act, render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import AppContext, { UserContext, UserLogInContext } from '../app-context/app-context';
-import AppCore from './app-core';
+import { act, render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { routes } from '../../../shared/routes';
+import AppCore from './app-core';
 
 jest.mock('../app-public/app-public', () => {
   return {
@@ -40,16 +40,15 @@ const TestComponent = () => {
 };
 
 // Sets up the component under test with the desired values and renders it
-const renderComponent = () => {
-  render(
-    <MemoryRouter initialEntries={['/']}>
-      <Route path={'/'}>
-        <AppContext>
-          <AppCore />
-          <TestComponent />
-        </AppContext>
-      </Route>
-    </MemoryRouter>
+const renderComponent = (route?: string) => {
+  const RouterWrapper = routerWrapperBuilder({ route });
+  return render(
+    <RouterWrapper>
+      <AppContext>
+        <AppCore />
+        <TestComponent />
+      </AppContext>
+    </RouterWrapper>
   );
 };
 
@@ -93,12 +92,12 @@ describe('app core', () => {
   });
 
   it('no stored user', () => {
-    renderComponent();
+    renderComponent(routes.CHANGE_REQUESTS);
 
     expect(localStorage.getItem).toBeCalledTimes(2);
     expect(localStorage.getItem).toBeCalledWith('userId');
     expect(localStorage.setItem).toBeCalledTimes(1);
-    expect(localStorage.setItem).toBeCalledWith('redirectUrl', routes.LOGIN);
+    expect(localStorage.setItem).toBeCalledWith('redirectUrl', routes.CHANGE_REQUESTS);
 
     expect(pushed).toEqual([routes.LOGIN]);
 

--- a/src/components/app/app-main/app-main.test.tsx
+++ b/src/components/app/app-main/app-main.test.tsx
@@ -3,8 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
-import { renderWithRouter } from '../../../test-support/test-utils';
+import { render, screen } from '../../../test-support/test-utils';
 import AppMain from './app-main';
 
 jest.mock('../app-core/app-core', () => {
@@ -27,14 +26,14 @@ jest.mock('../app-context/app-context', () => {
 });
 
 // Sets up the component under test with the desired values and renders it
-const renderComponent = (path?: string, route?: string) => {
-  renderWithRouter(<AppMain />, { path, route });
+const renderComponent = () => {
+  render(<AppMain />);
 };
 
 describe('app main, entry component', () => {
   it('renders the app context component', () => {
     renderComponent();
-    expect(screen.getByText('context')).toBeInTheDocument();
+    expect(screen.getAllByText('context')[0]).toBeInTheDocument();
   });
 
   it('renders the app core component', () => {

--- a/src/components/app/app-main/app-main.tsx
+++ b/src/components/app/app-main/app-main.tsx
@@ -3,6 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { BrowserRouter } from 'react-router-dom';
 import AppContext from '../app-context/app-context';
 import AppCore from '../app-core/app-core';
 import './app-main.module.css';
@@ -10,7 +11,9 @@ import './app-main.module.css';
 const AppMain: React.FC = () => {
   return (
     <AppContext>
-      <AppCore />
+      <BrowserRouter>
+        <AppCore />
+      </BrowserRouter>
     </AppContext>
   );
 };

--- a/src/components/app/app-public/app-public.test.tsx
+++ b/src/components/app/app-public/app-public.test.tsx
@@ -3,8 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
-import { renderWithRouter } from '../../../test-support/test-utils';
+import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { routes } from '../../../shared/routes';
 import AppPublic from './app-public';
 
@@ -19,7 +18,12 @@ jest.mock('../app-authenticated/app-authenticated', () => {
 
 // Sets up the component under test with the desired values and renders it
 const renderComponent = (path?: string, route?: string) => {
-  renderWithRouter(<AppPublic />, { path, route });
+  const RouterWrapper = routerWrapperBuilder({ path, route });
+  return render(
+    <RouterWrapper>
+      <AppPublic />
+    </RouterWrapper>
+  );
 };
 
 describe('app public section', () => {

--- a/src/components/change-requests/change-request-details/change-request-details.test.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details.test.tsx
@@ -3,11 +3,10 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
 import { UseQueryResult } from 'react-query';
-import { ChangeRequest, exampleStandardChangeRequest } from 'utils';
-import { routes } from '../../../shared/routes';
-import { renderWithRouter } from '../../../test-support/test-utils';
+import { ChangeRequest } from 'utils';
+import { exampleStandardChangeRequest } from '../../../test-support/test-data/change-requests.stub';
+import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { mockUseQueryResult } from '../../../test-support/test-data/test-utils.stub';
 import { useSingleChangeRequest } from '../../../services/change-requests.hooks';
 import ChangeRequestDetails from './change-request-details';
@@ -28,10 +27,12 @@ const mockHook = (isLoading: boolean, isError: boolean, data?: ChangeRequest, er
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<ChangeRequestDetails />, {
-    path: routes.CHANGE_REQUESTS_BY_ID,
-    route: `${routes.CHANGE_REQUESTS}/1`
-  });
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <ChangeRequestDetails />
+    </RouterWrapper>
+  );
 };
 
 describe('change request details container', () => {

--- a/src/components/change-requests/change-requests.test.tsx
+++ b/src/components/change-requests/change-requests.test.tsx
@@ -3,9 +3,8 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../shared/routes';
-import { renderWithRouter } from '../../test-support/test-utils';
 import ChangeRequests from './change-requests';
 
 jest.mock('./change-requests-table/change-requests-table', () => {
@@ -26,21 +25,27 @@ jest.mock('./change-request-details/change-request-details', () => {
   };
 });
 
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = (route: string) => {
+  const RouterWrapper = routerWrapperBuilder({ route });
+  return render(
+    <RouterWrapper>
+      <ChangeRequests />
+    </RouterWrapper>
+  );
+};
+
 describe('change request page', () => {
   it('renders the change requests list page', () => {
-    renderWithRouter(<ChangeRequests />, {
-      path: routes.CHANGE_REQUESTS,
-      route: routes.CHANGE_REQUESTS
-    });
+    renderComponent(routes.CHANGE_REQUESTS);
 
     expect(screen.getByText('change-requests-table')).toBeInTheDocument();
   });
 
   it('renders the change request id title', async () => {
-    renderWithRouter(<ChangeRequests />, {
-      path: routes.CHANGE_REQUESTS_BY_ID,
-      route: `${routes.CHANGE_REQUESTS}/37`
-    });
+    renderComponent(routes.CHANGE_REQUESTS_BY_ID);
 
     expect(screen.getByText('change-request-details')).toBeInTheDocument();
   });

--- a/src/components/home/home.test.tsx
+++ b/src/components/home/home.test.tsx
@@ -3,16 +3,20 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../shared/routes';
-import { renderWithRouter } from '../../test-support/test-utils';
 import Home from './home';
 
 /**
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<Home />, { path: routes.HOME, route: routes.HOME });
+  const RouterWrapper = routerWrapperBuilder({ path: routes.HOME, route: routes.HOME });
+  return render(
+    <RouterWrapper>
+      <Home />
+    </RouterWrapper>
+  );
 };
 
 describe('home component', () => {

--- a/src/components/projects/projects-table/projects-table.test.tsx
+++ b/src/components/projects/projects-table/projects-table.test.tsx
@@ -3,10 +3,9 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { UseQueryResult } from 'react-query';
 import { WorkPackage, Project } from 'utils';
-import { wbsRegex } from '../../../test-support/test-utils';
+import { wbsRegex, fireEvent, render, screen, waitFor } from '../../../test-support/test-utils';
 import { wbsPipe, fullNamePipe } from '../../../shared/pipes';
 import { useAllProjects } from '../../../services/projects.hooks';
 import { exampleAllProjects } from '../../../test-support/test-data/projects.stub';

--- a/src/components/projects/projects.test.tsx
+++ b/src/components/projects/projects.test.tsx
@@ -3,9 +3,8 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../shared/routes';
-import { renderWithRouter } from '../../test-support/test-utils';
 import Projects from './projects';
 
 jest.mock('./projects-table/projects-table', () => {
@@ -29,20 +28,24 @@ jest.mock('./wbs-details/wbs-details', () => {
 /**
  * Sets up the component under test with the desired values and renders it.
  */
-const renderComponent = (routeOverride?: string) => {
-  const renderRoute: string = routeOverride || routes.PROJECTS;
-  renderWithRouter(<Projects />, { route: renderRoute });
+const renderComponent = (route: string) => {
+  const RouterWrapper = routerWrapperBuilder({ route });
+  return render(
+    <RouterWrapper>
+      <Projects />
+    </RouterWrapper>
+  );
 };
 
 describe('projects page component', () => {
   it('renders the projects table page title', () => {
-    renderComponent();
+    renderComponent(routes.PROJECTS);
+
     expect(screen.getByText('Projects Table')).toBeInTheDocument();
   });
 
   it('renders the wbs element page title', () => {
-    const wbsNumToRender: string = '1.8.1';
-    renderComponent(`${routes.PROJECTS}/${wbsNumToRender}`);
+    renderComponent(`${routes.PROJECTS}/1.8.1`);
     expect(screen.getByText('WBS Details')).toBeInTheDocument();
   });
 });

--- a/src/components/projects/wbs-details/project-container/project-container.test.tsx
+++ b/src/components/projects/wbs-details/project-container/project-container.test.tsx
@@ -3,11 +3,12 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
 import { UseQueryResult } from 'react-query';
-import { exampleProject1, Project } from 'utils';
-import { renderWithRouter } from '../../../../test-support/test-utils';
+import { Project } from 'utils';
+import { render, screen, routerWrapperBuilder } from '../../../../test-support/test-utils';
 import { mockUseQueryResult } from '../../../../test-support/test-data/test-utils.stub';
+import { exampleWbsProject1 } from '../../../../test-support/test-data/wbs-numbers.stub';
+import { exampleProject1 } from '../../../../test-support/test-data/projects.stub';
 import { useSingleProject } from '../../../../services/projects.hooks';
 import ProjectContainer from './project-container';
 
@@ -23,7 +24,12 @@ const mockHook = (isLoading: boolean, isError: boolean, data?: Project, error?: 
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = () => {
-  renderWithRouter(<ProjectContainer wbsNum={{ car: 1, project: 1, workPackage: 0 }} />, {});
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <ProjectContainer wbsNum={exampleWbsProject1} />
+    </RouterWrapper>
+  );
 };
 
 describe('Rendering Project Container', () => {
@@ -40,7 +46,7 @@ describe('Rendering Project Container', () => {
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    expect(screen.getByText('1.1.0 - Impact Attenuator')).toBeInTheDocument();
+    expect(screen.getByText('1.12.0 - Impact Attenuator')).toBeInTheDocument();
     expect(screen.getByText('Project Details')).toBeInTheDocument();
     expect(screen.getByText('Work Packages')).toBeInTheDocument();
     expect(screen.getByText('Bodywork Concept of Design')).toBeInTheDocument();

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
@@ -3,20 +3,24 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
 import { WorkPackage } from 'utils';
+import { render, screen, routerWrapperBuilder } from '../../../../../test-support/test-utils';
 import { dollarsPipe, wbsPipe, listPipe, endDatePipe } from '../../../../../shared/pipes';
 import {
   exampleWorkPackage1,
   exampleWorkPackage2,
   exampleWorkPackage3
 } from '../../../../../test-support/test-data/work-packages.stub';
-import { renderWithRouter } from '../../../../../test-support/test-utils';
 import WorkPackageSummary from './work-package-summary';
 
 // Sets up the component under test with the desired values and renders it
 const renderComponent = (wps: WorkPackage, path?: string, route?: string) => {
-  renderWithRouter(<WorkPackageSummary workPackage={wps} />, { path, route });
+  const RouterWrapper = routerWrapperBuilder({ path, route });
+  return render(
+    <RouterWrapper>
+      <WorkPackageSummary workPackage={wps} />
+    </RouterWrapper>
+  );
 };
 
 describe('Rendering Work Packagae Summary Test', () => {

--- a/src/components/projects/wbs-details/wbs-details.test.tsx
+++ b/src/components/projects/wbs-details/wbs-details.test.tsx
@@ -3,9 +3,8 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { routes } from '../../../shared/routes';
-import { renderWithRouter } from '../../../test-support/test-utils';
 import WBSDetails from './wbs-details';
 
 jest.mock('./project-container/project-container', () => {
@@ -32,10 +31,15 @@ jest.mock('./work-package-container/work-package-container', () => {
  * @param options WBS number to render the component at
  */
 const renderComponent = (wbsNumber: string) => {
-  renderWithRouter(<WBSDetails />, {
+  const RouterWrapper = routerWrapperBuilder({
     path: routes.PROJECTS_BY_WBS,
     route: `${routes.PROJECTS}/${wbsNumber}`
   });
+  return render(
+    <RouterWrapper>
+      <WBSDetails />
+    </RouterWrapper>
+  );
 };
 
 describe('wbs element details component', () => {

--- a/src/components/projects/wbs-details/work-package-container/work-package-changes/work-package-changes.test.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-changes/work-package-changes.test.tsx
@@ -3,20 +3,31 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
-import WorkPackageChanges from './work-package-changes';
-import { renderWithRouter } from '../../../../../test-support/test-utils';
+import { render, screen, routerWrapperBuilder } from '../../../../../test-support/test-utils';
 import { exampleWorkPackage2 } from '../../../../../test-support/test-data/work-packages.stub';
+import WorkPackageChanges from './work-package-changes';
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = () => {
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <WorkPackageChanges workPackage={exampleWorkPackage2} />
+    </RouterWrapper>
+  );
+};
 
 describe('Rendering Work Package Changes Component', () => {
   it('renders the component title', () => {
-    renderWithRouter(<WorkPackageChanges workPackage={exampleWorkPackage2} />, {});
+    renderComponent();
 
     expect(screen.getByText(`Changes`)).toBeInTheDocument();
   });
 
   it('renders all the changes', () => {
-    renderWithRouter(<WorkPackageChanges workPackage={exampleWorkPackage2} />, {});
+    renderComponent();
 
     expect(screen.getByText('#1')).toBeInTheDocument();
     expect(screen.getByText(/Decreased duration from 10 weeks to 7 weeks./i)).toBeInTheDocument();

--- a/src/components/projects/wbs-details/work-package-container/work-package-container.test.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-container.test.tsx
@@ -2,10 +2,9 @@
  * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-import { screen } from '@testing-library/react';
 import { UseQueryResult } from 'react-query';
 import { WorkPackage } from 'utils';
-import { renderWithRouter } from '../../../../test-support/test-utils';
+import { render, screen, routerWrapperBuilder } from '../../../../test-support/test-utils';
 import { mockUseQueryResult } from '../../../../test-support/test-data/test-utils.stub';
 import { exampleWbsProject1 } from '../../../../test-support/test-data/wbs-numbers.stub';
 import { exampleWorkPackage1 } from '../../../../test-support/test-data/work-packages.stub';
@@ -24,7 +23,12 @@ const mockHook = (isLoading: boolean, isError: boolean, data?: WorkPackage, erro
 
 // Sets up the component under test with the desired values and renders it.
 const renderComponent = () => {
-  renderWithRouter(<WorkPackageContainer wbsNum={exampleWbsProject1} />, {});
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <WorkPackageContainer wbsNum={exampleWbsProject1} />
+    </RouterWrapper>
+  );
 };
 
 describe('work package container', () => {

--- a/src/components/projects/wbs-details/work-package-container/work-package-dependencies/work-package-dependencies.test.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-dependencies/work-package-dependencies.test.tsx
@@ -3,15 +3,19 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen, routerWrapperBuilder } from '../../../../../test-support/test-utils';
 import { wbsPipe } from '../../../../../shared/pipes';
 import { exampleWorkPackage2 } from '../../../../../test-support/test-data/work-packages.stub';
 import WorkPackageDependencies from './work-package-dependencies';
-import { renderWithRouter } from '../../../../../test-support/test-utils';
 
 // Sets up the component under test with the desired values and renders it
 const renderComponent = (path?: string, route?: string) => {
-  renderWithRouter(<WorkPackageDependencies workPackage={exampleWorkPackage2} />, { path, route });
+  const RouterWrapper = routerWrapperBuilder({ path, route });
+  return render(
+    <RouterWrapper>
+      <WorkPackageDependencies workPackage={exampleWorkPackage2} />
+    </RouterWrapper>
+  );
 };
 
 describe('Rendering Work Packagae Dependencies Component', () => {

--- a/src/components/settings/settings.test.tsx
+++ b/src/components/settings/settings.test.tsx
@@ -3,16 +3,20 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen, routerWrapperBuilder } from '../../test-support/test-utils';
 import { routes } from '../../shared/routes';
-import { renderWithRouter } from '../../test-support/test-utils';
 import Settings from './settings';
 
 /**
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<Settings />, { path: routes.SETTINGS, route: routes.SETTINGS });
+  const RouterWrapper = routerWrapperBuilder({ path: routes.SETTINGS, route: routes.SETTINGS });
+  return render(
+    <RouterWrapper>
+      <Settings />
+    </RouterWrapper>
+  );
 };
 
 describe('settings page component', () => {

--- a/src/components/whole-app/login/login.test.tsx
+++ b/src/components/whole-app/login/login.test.tsx
@@ -4,8 +4,7 @@
  */
 
 import { useHistory } from 'react-router-dom';
-import { fireEvent, screen } from '@testing-library/react';
-import { renderWithRouter } from '../../../test-support/test-utils';
+import { render, screen, fireEvent, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { routes } from '../../../shared/routes';
 import Login from './login';
 
@@ -23,7 +22,12 @@ const renderComponent = () => {
     });
     return <Login />;
   };
-  renderWithRouter(<TestComponent />, { path: routes.LOGIN, route: routes.LOGIN });
+  const RouterWrapper = routerWrapperBuilder({ path: routes.LOGIN, route: routes.LOGIN });
+  return render(
+    <RouterWrapper>
+      <TestComponent />
+    </RouterWrapper>
+  );
 };
 
 describe('login component', () => {

--- a/src/components/whole-app/nav-top-bar/nav-notifications-menu/nav-notifications-menu.test.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-notifications-menu/nav-notifications-menu.test.tsx
@@ -3,15 +3,25 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithRouter } from '../../../../test-support/test-utils';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  routerWrapperBuilder
+} from '../../../../test-support/test-utils';
 import NavNotificationsMenu from './nav-notifications-menu';
 
 /**
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<NavNotificationsMenu />, {});
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <NavNotificationsMenu />
+    </RouterWrapper>
+  );
 };
 
 describe('navigation notifications menu tests', () => {

--- a/src/components/whole-app/nav-top-bar/nav-page-links/nav-page-links.test.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-page-links/nav-page-links.test.tsx
@@ -3,15 +3,19 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
-import { renderWithRouter } from '../../../../test-support/test-utils';
+import { render, screen, routerWrapperBuilder } from '../../../../test-support/test-utils';
 import NavPageLinks from './nav-page-links';
 
 /**
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<NavPageLinks />, {});
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <NavPageLinks />
+    </RouterWrapper>
+  );
 };
 
 describe('navigation page links tests', () => {

--- a/src/components/whole-app/nav-top-bar/nav-top-bar.test.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-top-bar.test.tsx
@@ -3,15 +3,19 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { screen } from '@testing-library/react';
-import { renderWithRouter } from '../../../test-support/test-utils';
+import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import NavTopBar from './nav-top-bar';
 
 /**
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<NavTopBar />, {});
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <NavTopBar />
+    </RouterWrapper>
+  );
 };
 
 describe('navigation top bar tests', () => {

--- a/src/components/whole-app/nav-top-bar/nav-user-menu/nav-user-menu.test.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-user-menu/nav-user-menu.test.tsx
@@ -3,15 +3,25 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithRouter } from '../../../../test-support/test-utils';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  routerWrapperBuilder
+} from '../../../../test-support/test-utils';
 import NavUserMenu from './nav-user-menu';
 
 /**
  * Sets up the component under test with the desired values and renders it.
  */
 const renderComponent = () => {
-  renderWithRouter(<NavUserMenu />, {});
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <NavUserMenu />
+    </RouterWrapper>
+  );
 };
 
 describe('navigation user menu tests', () => {

--- a/src/test-support/test-utils.tsx
+++ b/src/test-support/test-utils.tsx
@@ -3,30 +3,38 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render } from '@testing-library/react';
 import { ReactElement } from 'react';
-import { MemoryRouter, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { render, RenderOptions } from '@testing-library/react';
+import { routes } from '../shared/routes';
+import AppContext from '../components/app/app-context/app-context';
 
 // Regular Expression to match WBS Numbers
-export const wbsRegex: RegExp = /[1-2]\.([1-9]{1}([0-9]{1})?)\.[0-9]{1,2}/;
+const wbsRegex: RegExp = /[1-2]\.([1-9]{1}([0-9]{1})?)\.[0-9]{1,2}/;
 
-/**
- * Render a React component wrapped in a memory router for testing.
- *
- * @param ui React component under test
- * @param options Path to place component and route to navigate to (both optional)
- */
-export const renderWithRouter = (ui: ReactElement, { path = '/', route = '/' }) => {
-  const toRender: ReactElement = (
-    <MemoryRouter initialEntries={[route]}>
-      <Route path={path}>{ui}</Route>
-    </MemoryRouter>
-  );
-  render(toRender);
-};
-
-export const queryClientProviderWrapper = ({ children }: any) => {
+// mostly for services hooks tests
+const queryClientProviderWrapper = ({ children }: any) => {
   const queryClient = new QueryClient();
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };
+
+// to allow configuring paths/routes within tests
+const routerWrapperBuilder = ({ path = routes.HOME, route = routes.HOME }) => {
+  const RouterWrapper: React.FC = ({ children }) => {
+    return (
+      <MemoryRouter initialEntries={[route]}>
+        <Route path={path}>{children}</Route>
+      </MemoryRouter>
+    );
+  };
+  return RouterWrapper;
+};
+
+// always provide contexts and providers in test renders
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'queries'>) =>
+  render(ui, { wrapper: AppContext, ...options });
+
+export * from '@testing-library/react';
+
+export { wbsRegex, queryClientProviderWrapper, routerWrapperBuilder, customRender as render };


### PR DESCRIPTION
Lots of refactoring and figuring out what will work with what is needed. Shifted around routers and providers to better accommodate new pattern. Updated all tests to ensure robustness and passing. Closes #252.