### PR TITLE
#301 move budget

### DIFF
--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -152,6 +152,7 @@ model Project {
   projectId             Int                  @id @default(autoincrement())
   wbsElementId          Int
   wbsElement            WBS_Element          @relation(fields: [wbsElementId], references: [wbsElementId])
+  budget                Int
   googleDriveFolderLink String
   slideDeckLink         String
   bomLink               String
@@ -173,7 +174,6 @@ model Work_Package {
   startDate          DateTime
   progress           Int
   duration           Int
-  budget             Int
   dependencies       WBS_Element[]        @relation(name: "dependencies")
   expectedActivities Description_Bullet[] @relation(name: "workPackageExpectedActivities")
   deliverables       Description_Bullet[] @relation(name: "workPackageDeliverables")

--- a/src/backend/prisma/seed-data/projects.ts
+++ b/src/backend/prisma/seed-data/projects.ts
@@ -5,15 +5,6 @@
 
 import { WBS_Element_Status } from '@prisma/client';
 
-const dbSeedProjectLinks: any = {
-  googleDriveFolderLink: 'https://youtu.be/dQw4w9WgXcQ',
-  taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
-  slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
-  bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  budget: 124,
-  rules: ['EV3.5.2', 'T12.3.2', 'T8.2.6', 'EV1.4.7', 'EV6.3.10']
-};
-
 const dbSeedProject1: any = {
   wbsElementFields: {
     carNumber: 1,
@@ -25,7 +16,14 @@ const dbSeedProject1: any = {
     projectLeadId: 4,
     projectManagerId: 5
   },
-  projectFields: dbSeedProjectLinks,
+  projectFields: {
+    googleDriveFolderLink: 'https://youtu.be/dQw4w9WgXcQ',
+    taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
+    slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
+    bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+    budget: 124,
+    rules: ['EV3.5.2']
+  },
   goals: [
     {
       detail: 'Decrease size by 90% from 247 cubic inches to 24.7 cubic inches',
@@ -56,7 +54,14 @@ const dbSeedProject2: any = {
     projectLeadId: 3,
     projectManagerId: 4
   },
-  projectFields: dbSeedProjectLinks,
+  projectFields: {
+    googleDriveFolderLink: 'https://youtu.be/dQw4w9WgXcQ',
+    taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
+    slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
+    bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+    budget: 50,
+    rules: ['T12.3.2', 'T8.2.6']
+  },
   goals: [
     {
       detail: 'Decrease weight by 90% from 4.8 pounds to 0.48 pounds',
@@ -88,7 +93,14 @@ const dbSeedProject3: any = {
     projectLeadId: 2,
     projectManagerId: 3
   },
-  projectFields: dbSeedProjectLinks,
+  projectFields: {
+    googleDriveFolderLink: 'https://youtu.be/dQw4w9WgXcQ',
+    taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
+    slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
+    bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+    budget: 5000,
+    rules: ['EV3.5.2', 'EV1.4.7', 'EV6.3.10']
+  },
   goals: [
     {
       detail: 'Decrease weight by 60% from 100 pounds to 40 pounds',
@@ -120,7 +132,14 @@ const dbSeedProject4: any = {
     projectLeadId: 4,
     projectManagerId: 5
   },
-  projectFields: dbSeedProjectLinks,
+  projectFields: {
+    googleDriveFolderLink: 'https://youtu.be/dQw4w9WgXcQ',
+    taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
+    slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
+    bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+    budget: 0,
+    rules: []
+  },
   goals: [
     {
       detail: 'Power consumption stays under 10 watts from the low voltage system',
@@ -152,7 +171,14 @@ const dbSeedProject5: any = {
     projectLeadId: 4,
     projectManagerId: 5
   },
-  projectFields: dbSeedProjectLinks,
+  projectFields: {
+    googleDriveFolderLink: 'https://youtu.be/dQw4w9WgXcQ',
+    taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
+    slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
+    bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+    budget: 234,
+    rules: ['EV3.5.2', 'T12.3.2', 'T8.2.6', 'EV1.4.7', 'EV6.3.10']
+  },
   goals: [
     {
       detail: 'Decrease installed component costs by 63% from $2,700 to $1000',

--- a/src/backend/prisma/seed-data/projects.ts
+++ b/src/backend/prisma/seed-data/projects.ts
@@ -10,6 +10,7 @@ const dbSeedProjectLinks: any = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+  budget: 124,
   rules: ['EV3.5.2', 'T12.3.2', 'T8.2.6', 'EV1.4.7', 'EV6.3.10']
 };
 

--- a/src/backend/prisma/seed-data/work-packages.ts
+++ b/src/backend/prisma/seed-data/work-packages.ts
@@ -21,8 +21,7 @@ const dbSeedWorkPackage1: any = {
     orderInProject: 1,
     startDate: new Date('01/01/21'),
     progress: 25,
-    duration: 3,
-    budget: 0
+    duration: 3
   },
   expectedActivities: [
     {
@@ -60,8 +59,7 @@ const dbSeedWorkPackage2: any = {
     orderInProject: 2,
     startDate: new Date('01/01/21'),
     progress: 0,
-    duration: 5,
-    budget: 75
+    duration: 5
   },
   expectedActivities: [
     {
@@ -103,8 +101,7 @@ const dbSeedWorkPackage3: any = {
     orderInProject: 3,
     startDate: new Date('01/01/21'),
     progress: 100,
-    duration: 2,
-    budget: 124
+    duration: 2
   },
   expectedActivities: [
     {

--- a/src/components/projects/wbs-details/project-container/project-details/project-details.tsx
+++ b/src/components/projects/wbs-details/project-container/project-details/project-details.tsx
@@ -36,8 +36,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }: ProjectDetai
           <b>Project Manager:</b> {fullNamePipe(project.projectManager)}
         </p>
         <p>
-          <b>Budget:</b>{' '}
-          {dollarsPipe(project.workPackages.reduce((tot, cur) => tot + cur.budget, 0))}
+          <b>Budget:</b> {dollarsPipe(project.budget)}
         </p>
         <div className={styles.horizontal}>
           <li>{linkPipe('Slide Deck', project.slideDeckLink)}</li>

--- a/src/components/projects/wbs-details/project-container/rules-list/rules-list.test.tsx
+++ b/src/components/projects/wbs-details/project-container/rules-list/rules-list.test.tsx
@@ -17,7 +17,6 @@ describe('Rendering Work Package Rules Component', () => {
   it('renders all the listed rules', () => {
     render(<RulesList rules={exampleProject1.rules} />);
 
-    expect(screen.getByText('T12.3.2')).toBeInTheDocument();
-    expect(screen.getByText('T8.2.6')).toBeInTheDocument();
+    expect(screen.getByText('EV3.5.2')).toBeInTheDocument();
   });
 });

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
@@ -5,7 +5,7 @@
 
 import { WorkPackage } from 'utils';
 import { render, screen, routerWrapperBuilder } from '../../../../../test-support/test-utils';
-import { dollarsPipe, wbsPipe, listPipe, endDatePipe } from '../../../../../shared/pipes';
+import { wbsPipe, listPipe, endDatePipe } from '../../../../../shared/pipes';
 import {
   exampleWorkPackage1,
   exampleWorkPackage2,
@@ -30,7 +30,6 @@ describe('Rendering Work Packagae Summary Test', () => {
     expect(screen.getByText(`${wp.name}`)).toBeInTheDocument();
     expect(screen.getByText(`${wbsPipe(wp.wbsNum)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.duration} weeks`)).toBeInTheDocument();
-    expect(screen.getByText(`${dollarsPipe(wp.budget)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`)).toBeInTheDocument();
     expect(screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`)).toBeInTheDocument();
   });
@@ -42,7 +41,6 @@ describe('Rendering Work Packagae Summary Test', () => {
     expect(screen.getByText(`${wbsPipe(wp.wbsNum)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.duration} weeks`)).toBeInTheDocument();
     expect(screen.getByText(`${listPipe(wp.dependencies, wbsPipe)}`)).toBeInTheDocument();
-    expect(screen.getByText(`${dollarsPipe(wp.budget)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`)).toBeInTheDocument();
     expect(screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`)).toBeInTheDocument();
   });
@@ -54,7 +52,6 @@ describe('Rendering Work Packagae Summary Test', () => {
     expect(screen.getByText(`${wbsPipe(wp.wbsNum)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.duration} weeks`)).toBeInTheDocument();
     expect(screen.getByText(`${listPipe(wp.dependencies, wbsPipe)}`)).toBeInTheDocument();
-    expect(screen.getByText(`${dollarsPipe(wp.budget)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`)).toBeInTheDocument();
     expect(screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`)).toBeInTheDocument();
   });

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
@@ -7,13 +7,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Collapse } from 'react-bootstrap';
 import { WorkPackage } from 'utils';
-import {
-  weeksPipe,
-  dollarsPipe,
-  wbsPipe,
-  endDatePipe,
-  listPipe
-} from '../../../../../shared/pipes';
+import { weeksPipe, wbsPipe, endDatePipe, listPipe } from '../../../../../shared/pipes';
 import { routes } from '../../../../../shared/routes';
 import styles from './work-package-summary.module.css';
 
@@ -41,9 +35,6 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
             <div className={styles.halfDiv}>
               <p>
                 <b>Dependencies:</b> {listPipe(workPackage.dependencies, wbsPipe)}
-              </p>
-              <p>
-                <b>Budget:</b> {dollarsPipe(workPackage.budget)}
               </p>
             </div>
             <div className={styles.halfDiv}>

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.test.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.test.tsx
@@ -5,7 +5,7 @@
 
 import { render, screen } from '@testing-library/react';
 import { WorkPackage } from 'utils';
-import { dollarsPipe, endDatePipe, fullNamePipe, weeksPipe } from '../../../../../shared/pipes';
+import { endDatePipe, fullNamePipe, weeksPipe } from '../../../../../shared/pipes';
 import {
   exampleWorkPackage1,
   exampleWorkPackage2,
@@ -22,7 +22,6 @@ describe('Rendering Work Packagae Details Component', () => {
     expect(screen.getByText(`${wp.name}`)).toBeInTheDocument();
     expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`)).toBeInTheDocument();
     expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`)).toBeInTheDocument();
-    expect(screen.getByText(`${dollarsPipe(wp.budget)}`)).toBeInTheDocument();
 
     expect(screen.getByText(`${weeksPipe(wp.duration)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`)).toBeInTheDocument();
@@ -38,7 +37,6 @@ describe('Rendering Work Packagae Details Component', () => {
     expect(screen.getByText(`${wp.name}`)).toBeInTheDocument();
     expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`)).toBeInTheDocument();
     expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`)).toBeInTheDocument();
-    expect(screen.getByText(`${dollarsPipe(wp.budget)}`)).toBeInTheDocument();
 
     expect(screen.getByText(`${weeksPipe(wp.duration)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`)).toBeInTheDocument();
@@ -54,7 +52,6 @@ describe('Rendering Work Packagae Details Component', () => {
     expect(screen.getByText(`${wp.name}`)).toBeInTheDocument();
     expect(screen.getByText(`${fullNamePipe(wp.projectLead)}`)).toBeInTheDocument();
     expect(screen.getByText(`${fullNamePipe(wp.projectManager)}`)).toBeInTheDocument();
-    expect(screen.getByText(`${dollarsPipe(wp.budget)}`)).toBeInTheDocument();
 
     expect(screen.getByText(`${weeksPipe(wp.duration)}`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.startDate.toLocaleDateString()}`)).toBeInTheDocument();

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
@@ -28,11 +28,11 @@ const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) 
         <p>
           <b>Project Manager:</b> {fullNamePipe(workPackage.projectManager)}
         </p>
-      </div>
-      <div className={styles.halfDiv}>
         <p>
           <b>Duration:</b> {weeksPipe(workPackage.duration)}
         </p>
+      </div>
+      <div className={styles.halfDiv}>
         <p>
           <b>Start Date:</b> {workPackage.startDate.toLocaleDateString()}
         </p>

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
@@ -4,13 +4,7 @@
  */
 
 import { WorkPackage } from 'utils';
-import {
-  weeksPipe,
-  dollarsPipe,
-  wbsPipe,
-  endDatePipe,
-  fullNamePipe
-} from '../../../../../shared/pipes';
+import { weeksPipe, wbsPipe, endDatePipe, fullNamePipe } from '../../../../../shared/pipes';
 import PageBlock from '../../../../shared/page-block/page-block';
 import styles from './work-package-details.module.css';
 
@@ -33,9 +27,6 @@ const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) 
         </p>
         <p>
           <b>Project Manager:</b> {fullNamePipe(workPackage.projectManager)}
-        </p>
-        <p>
-          <b>Budget:</b> {dollarsPipe(workPackage.budget)}
         </p>
       </div>
       <div className={styles.halfDiv}>

--- a/src/services/tests/projects.api.test.ts
+++ b/src/services/tests/projects.api.test.ts
@@ -32,6 +32,7 @@ describe('project api hooks', () => {
     expect(result.data).toHaveProperty('length', 5);
     expect(result.data[0]).toHaveProperty('gDriveLink');
     expect(result.data[1]).toHaveProperty('status');
+    expect(result.data[0]).toHaveProperty('budget');
     expect(result.data[1]).toHaveProperty('projectLead');
   });
 

--- a/src/services/tests/work-packages.api.test.ts
+++ b/src/services/tests/work-packages.api.test.ts
@@ -35,7 +35,6 @@ describe('work package api methods', () => {
     expect(result.data).toHaveProperty('length', 3);
     expect(result.data[0]).toHaveProperty('progress');
     expect(result.data[1]).toHaveProperty('status');
-    expect(result.data[0]).toHaveProperty('budget');
     expect(result.data[1]).toHaveProperty('projectLead');
   });
 

--- a/src/shared/tests/list-pipe.test.tsx
+++ b/src/shared/tests/list-pipe.test.tsx
@@ -23,9 +23,11 @@ describe('Formatting lists tests', () => {
   });
 
   test('Formatting Rules', () => {
-    expect(listPipe(exampleProject1.rules, (str: string) => str)).toBe('T12.3.2, T8.2.6');
-    expect(listPipe(exampleProject2.rules, (str: string) => str)).toBe('EV1.4.7, EV6.3.10');
-    expect(listPipe(exampleProject3.rules, (str: string) => str)).toBe('EV3.5.2');
+    expect(listPipe(exampleProject1.rules, (str: string) => str)).toBe('EV3.5.2');
+    expect(listPipe(exampleProject2.rules, (str: string) => str)).toBe('T12.3.2, T8.2.6');
+    expect(listPipe(exampleProject3.rules, (str: string) => str)).toBe(
+      'EV3.5.2, EV1.4.7, EV6.3.10'
+    );
   });
 
   test('for other case', () => {

--- a/src/test-support/test-data/projects.stub.ts
+++ b/src/test-support/test-data/projects.stub.ts
@@ -30,7 +30,8 @@ export const exampleProject1: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['T12.3.2', 'T8.2.6'],
+  budget: 124,
+  rules: ['EV3.5.2'],
   goals: [
     {
       id: 15,
@@ -76,7 +77,8 @@ export const exampleProject2: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['EV1.4.7', 'EV6.3.10'],
+  budget: 50,
+  rules: ['T12.3.2', 'T8.2.6'],
   goals: [
     {
       id: 16,
@@ -110,7 +112,8 @@ export const exampleProject3: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['EV3.5.2'],
+  budget: 5000,
+  rules: ['EV3.5.2', 'EV1.4.7', 'EV6.3.10'],
   goals: [
     {
       id: 17,
@@ -148,7 +151,8 @@ export const exampleProject4: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['EV3.5.2'],
+  budget: 0,
+  rules: [],
   goals: [
     {
       id: 18,
@@ -182,7 +186,8 @@ export const exampleProject5: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['EV3.5.2'],
+  budget: 234,
+  rules: ['EV3.5.2', 'T12.3.2', 'T8.2.6', 'EV1.4.7', 'EV6.3.10'],
   goals: [
     {
       id: 19,

--- a/src/test-support/test-data/work-packages.stub.ts
+++ b/src/test-support/test-data/work-packages.stub.ts
@@ -31,7 +31,6 @@ export const exampleWorkPackage1: WorkPackage = {
   progress: 25,
   startDate: new Date('01/01/21'),
   duration: 3,
-  budget: 0,
   dependencies: [],
   expectedActivities: [
     {
@@ -81,7 +80,6 @@ export const exampleWorkPackage2: WorkPackage = {
   progress: 0,
   startDate: new Date('01/22/21'),
   duration: 5,
-  budget: 75,
   dependencies: [exampleWbsWorkPackage1],
   expectedActivities: [
     {
@@ -140,7 +138,6 @@ export const exampleWorkPackage3: WorkPackage = {
   progress: 100,
   startDate: new Date('01/01/21'),
   duration: 2,
-  budget: 124,
   dependencies: [exampleWbsProject1, exampleWbsProject2],
   expectedActivities: [
     {

--- a/src/utils/src/dummy-data.ts
+++ b/src/utils/src/dummy-data.ts
@@ -147,7 +147,6 @@ export const exampleWorkPackage1: WorkPackage = {
   progress: 25,
   startDate: new Date('01/01/21'),
   duration: 3,
-  budget: 0,
   dependencies: [],
   expectedActivities: [
     {
@@ -197,7 +196,6 @@ export const exampleWorkPackage2: WorkPackage = {
   progress: 0,
   startDate: new Date('01/22/21'),
   duration: 5,
-  budget: 75,
   dependencies: [exampleWbsWorkPackage1],
   expectedActivities: [
     {
@@ -256,7 +254,6 @@ export const exampleWorkPackage3: WorkPackage = {
   progress: 100,
   startDate: new Date('01/01/21'),
   duration: 2,
-  budget: 124,
   dependencies: [exampleWbsProject1, exampleWbsProject2],
   expectedActivities: [
     {
@@ -319,6 +316,7 @@ export const exampleProject1: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
+  budget: 124,
   rules: ['EV3.5.2'],
   goals: [
     {
@@ -365,7 +363,8 @@ export const exampleProject2: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['EV1.4.7', 'EV6.3.10'],
+  budget: 50,
+  rules: ['T12.3.2', 'T8.2.6'],
   goals: [
     {
       id: 16,
@@ -399,7 +398,8 @@ export const exampleProject3: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['T12.3.2', 'T8.2.6'],
+  budget: 5000,
+  rules: ['EV3.5.2', 'EV1.4.7', 'EV6.3.10'],
   goals: [
     {
       id: 17,
@@ -437,7 +437,8 @@ export const exampleProject4: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['T12.3.2', 'T8.2.6'],
+  budget: 0,
+  rules: [],
   goals: [
     {
       id: 18,
@@ -471,7 +472,8 @@ export const exampleProject5: Project = {
   taskListLink: 'https://youtu.be/dQw4w9WgXcQ',
   slideDeckLink: 'https://youtu.be/dQw4w9WgXcQ',
   bomLink: 'https://youtu.be/dQw4w9WgXcQ',
-  rules: ['T12.3.2', 'T8.2.6'],
+  budget: 234,
+  rules: ['EV3.5.2', 'T12.3.2', 'T8.2.6', 'EV1.4.7', 'EV6.3.10'],
   goals: [
     {
       id: 19,

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -30,6 +30,7 @@ export enum WbsElementStatus {
 }
 
 export interface Project extends WbsElement {
+  budget: number;
   gDriveLink: string;
   taskListLink: string;
   slideDeckLink: string;
@@ -46,7 +47,6 @@ export interface WorkPackage extends WbsElement {
   progress: number;
   startDate: Date;
   duration: number;
-  budget: number;
   dependencies: WbsNumber[];
   expectedActivities: DescriptionBullet[];
   deliverables: DescriptionBullet[];


### PR DESCRIPTION
Moving budget from defined in work packages to just defined in projects. Also restyling the work package details to rebalance the two columns after removing the budget from that. Closes #301.