### PR TITLE
#243 - Update Projects API endpoint

### DIFF
--- a/src/backend/functions/projects.ts
+++ b/src/backend/functions/projects.ts
@@ -24,8 +24,8 @@ const getAllProjects: ApiRouteFunction = () => {
 };
 
 // Fetch the project for the specified WBS number
-const getSingleProject: ApiRouteFunction = (params: { wbs: string }) => {
-  const parseWbs: number[] = params.wbs.split('.').map((str) => parseInt(str));
+const getSingleProject: ApiRouteFunction = (params: { wbsNum: string }) => {
+  const parseWbs: number[] = params.wbsNum.split('.').map((str) => parseInt(str));
   const parsedWbs: WbsNumber = {
     car: parseWbs[0],
     project: parseWbs[1],
@@ -39,7 +39,7 @@ const getSingleProject: ApiRouteFunction = (params: { wbs: string }) => {
     );
   });
   if (requestedProject === undefined) {
-    return buildNotFoundResponse('project', `WBS # ${params.wbs}`);
+    return buildNotFoundResponse('project', `WBS # ${params.wbsNum}`);
   }
   return buildSuccessResponse(requestedProject);
 };

--- a/src/backend/functions/projects.ts
+++ b/src/backend/functions/projects.ts
@@ -7,6 +7,7 @@ import { Handler } from '@netlify/functions';
 import {
   routeMatcher,
   ApiRoute,
+  apiRoutes,
   Project,
   WbsNumber,
   ApiRouteFunction,
@@ -45,12 +46,12 @@ const getSingleProject: ApiRouteFunction = (params: { wbs: string }) => {
 
 const routes: ApiRoute[] = [
   {
-    path: `${API_URL}/projects`,
+    path: API_URL + apiRoutes.PROJECTS,
     httpMethod: 'GET',
     func: getAllProjects
   },
   {
-    path: `${API_URL}/projects/:wbs`,
+    path: API_URL + apiRoutes.PROJECTS_BY_WBS,
     httpMethod: 'GET',
     func: getSingleProject
   }

--- a/src/utils/src/api-routes.ts
+++ b/src/utils/src/api-routes.ts
@@ -12,7 +12,7 @@ const USERS_LOGIN: string = `${USERS}/auth\\:login`;
 
 /**************** Projects Endpoint ****************/
 const PROJECTS: string = `/projects`;
-const PROJECTS_BY_WBS: string = `${PROJECTS}/:wbs`;
+const PROJECTS_BY_WBS: string = `${PROJECTS}/:wbsNum`;
 
 /**************** Work Packages Endpoint ****************/
 const WORK_PACKAGES: string = `/work-packages`;


### PR DESCRIPTION
Updated the Projects API endpoint to follow better design principles.

The API endpoint now uses the `apiRoutes` object, with the single project lookup function using `wbsNum` instead of `wbs`.

Signed-off-by: Lucas Sta Maria <lucas.stamaria@gmail.com>