### PR TITLE
#342 - Changed link tag to open to a new tab instead of current tab.

### DIFF
--- a/src/shared/pipes.tsx
+++ b/src/shared/pipes.tsx
@@ -14,7 +14,11 @@ import { User, WbsNumber } from 'utils';
  */
 
 export const linkPipe = (description: string, link: string): ReactElement => {
-  return <a href={link}>{description}</a>;
+  return (
+    <a href={link} target="_blank" rel="noopener noreferrer">
+      {description}
+    </a>
+  );
 };
 
 export const weeksPipe = (weeks: number): string => {
@@ -51,12 +55,12 @@ export const endDatePipe = (startDate: Date, durWeeks: number): string => {
 
 // Returns an empty string if a passed in string is empty, otherwise return the given string
 export const emptyStringPipe = (str: string): string => {
-  return (str === undefined || str === null) ? "" : str;
+  return str === undefined || str === null ? '' : str;
 };
 
 // Replace an empty string with an EM dash
 export const emDashPipe = (str: string): string => {
-  return (str === undefined || str === null) ? "—" : str;
+  return str === undefined || str === null ? '—' : str;
 };
 
 // return a given data as a string in the local en-US format


### PR DESCRIPTION
Used [this website](https://www.freecodecamp.org/news/how-to-use-html-to-open-link-in-new-tab/) to change the linkPipe element so it opens external links in a new tab instead of the same one.