### PR TITLE
#302 moved change request transformer to separate transformer file

### DIFF
--- a/src/services/change-requests.api.ts
+++ b/src/services/change-requests.api.ts
@@ -4,32 +4,9 @@
  */
 
 import axios from 'axios';
-import { ChangeRequest, ChangeRequestType } from 'utils';
+import { ChangeRequest } from 'utils';
 import { apiUrls } from '../shared/urls';
-
-/**
- * Transforms a change request to ensure deep field transformation of date objects.
- *
- * @param changeRequest Incoming change request object supplied by the HTTP response.
- * @returns Properly transformed change request object.
- */
-export const changeRequestTransformer = (changeRequest: ChangeRequest) => {
-  const data: any = {
-    ...changeRequest,
-    dateSubmitted: new Date(changeRequest.dateSubmitted),
-    dateReviewed: changeRequest.dateReviewed
-      ? new Date(changeRequest.dateReviewed)
-      : changeRequest.dateReviewed,
-    dateImplemented: changeRequest.dateImplemented
-      ? new Date(changeRequest.dateImplemented)
-      : changeRequest.dateImplemented
-  };
-  if (changeRequest.type === ChangeRequestType.Activation) {
-    data.startDate = new Date(data.startDate);
-  }
-  const output: ChangeRequest = data;
-  return output;
-};
+import { changeRequestTransformer } from './transformers/transformers';
 
 /**
  * Fetches all change requests.

--- a/src/services/change-requests.api.ts
+++ b/src/services/change-requests.api.ts
@@ -6,7 +6,7 @@
 import axios from 'axios';
 import { ChangeRequest } from 'utils';
 import { apiUrls } from '../shared/urls';
-import { changeRequestTransformer } from './transformers/transformers';
+import { changeRequestTransformer } from './transformers/change-requests.transformers';
 
 /**
  * Fetches all change requests.

--- a/src/services/projects.api.ts
+++ b/src/services/projects.api.ts
@@ -4,41 +4,10 @@
  */
 
 import axios from 'axios';
-import { DescriptionBullet, Project, WbsNumber } from 'utils';
+import { Project, WbsNumber } from 'utils';
 import { wbsPipe } from '../shared/pipes';
 import { apiUrls } from '../shared/urls';
-import { workPackageTransformer } from './work-packages.api';
-
-/**
- * Transforms a description bullet to ensure deep field transformation of date objects.
- *
- * @param bullet Incoming description bullet object supplied by the HTTP response.
- * @returns Properly transformed description bullet object.
- */
-export const descriptionBulletTransformer = (bullet: DescriptionBullet) => {
-  return {
-    ...bullet,
-    dateAdded: new Date(bullet.dateAdded),
-    dateDeleted: bullet.dateDeleted ? new Date(bullet.dateDeleted) : bullet.dateDeleted
-  };
-};
-
-/**
- * Transforms a project to ensure deep field transformation of date objects.
- *
- * @param project Incoming project object supplied by the HTTP response.
- * @returns Properly transformed project object.
- */
-const projectTransformer = (project: Project) => {
-  return {
-    ...project,
-    dateCreated: new Date(project.dateCreated),
-    workPackages: project.workPackages.map(workPackageTransformer),
-    goals: project.goals.map(descriptionBulletTransformer),
-    features: project.features.map(descriptionBulletTransformer),
-    otherConstraints: project.otherConstraints.map(descriptionBulletTransformer)
-  };
-};
+import { projectTransformer } from './transformers/projects.transformers';
 
 /**
  * Fetches all projects.

--- a/src/services/transformers/change-requests.transformers.ts
+++ b/src/services/transformers/change-requests.transformers.ts
@@ -4,7 +4,6 @@
  */
 
 import { ChangeRequest, ChangeRequestType } from 'utils';
-export {};
 
 /**
  * Transforms a change request to ensure deep field transformation of date objects.

--- a/src/services/transformers/projects.transformers.ts
+++ b/src/services/transformers/projects.transformers.ts
@@ -1,0 +1,38 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { DescriptionBullet, Project } from 'utils';
+import { workPackageTransformer } from './work-packages.transformers';
+
+/**
+ * Transforms a description bullet to ensure deep field transformation of date objects.
+ *
+ * @param bullet Incoming description bullet object supplied by the HTTP response.
+ * @returns Properly transformed description bullet object.
+ */
+export const descriptionBulletTransformer = (bullet: DescriptionBullet) => {
+  return {
+    ...bullet,
+    dateAdded: new Date(bullet.dateAdded),
+    dateDeleted: bullet.dateDeleted ? new Date(bullet.dateDeleted) : bullet.dateDeleted
+  };
+};
+
+/**
+ * Transforms a project to ensure deep field transformation of date objects.
+ *
+ * @param project Incoming project object supplied by the HTTP response.
+ * @returns Properly transformed project object.
+ */
+export const projectTransformer = (project: Project) => {
+  return {
+    ...project,
+    dateCreated: new Date(project.dateCreated),
+    workPackages: project.workPackages.map(workPackageTransformer),
+    goals: project.goals.map(descriptionBulletTransformer),
+    features: project.features.map(descriptionBulletTransformer),
+    otherConstraints: project.otherConstraints.map(descriptionBulletTransformer)
+  };
+};

--- a/src/services/transformers/transformers.ts
+++ b/src/services/transformers/transformers.ts
@@ -1,0 +1,31 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { ChangeRequest, ChangeRequestType } from 'utils';
+export {};
+
+/**
+ * Transforms a change request to ensure deep field transformation of date objects.
+ *
+ * @param changeRequest Incoming change request object supplied by the HTTP response.
+ * @returns Properly transformed change request object.
+ */
+export const changeRequestTransformer = (changeRequest: ChangeRequest) => {
+  const data: any = {
+    ...changeRequest,
+    dateSubmitted: new Date(changeRequest.dateSubmitted),
+    dateReviewed: changeRequest.dateReviewed
+      ? new Date(changeRequest.dateReviewed)
+      : changeRequest.dateReviewed,
+    dateImplemented: changeRequest.dateImplemented
+      ? new Date(changeRequest.dateImplemented)
+      : changeRequest.dateImplemented
+  };
+  if (changeRequest.type === ChangeRequestType.Activation) {
+    data.startDate = new Date(data.startDate);
+  }
+  const output: ChangeRequest = data;
+  return output;
+};

--- a/src/services/transformers/users.transformers.ts
+++ b/src/services/transformers/users.transformers.ts
@@ -1,0 +1,20 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { User } from 'utils';
+
+/**
+ * Transforms a user to ensure deep field transformation of date objects.
+ *
+ * @param user Incoming user object supplied by the HTTP response.
+ * @returns Properly transformed user object.
+ */
+export const userTransformer = (user: User) => {
+  return {
+    ...user,
+    firstLogin: new Date(user.firstLogin),
+    lastLogin: new Date(user.lastLogin)
+  };
+};

--- a/src/services/transformers/work-packages.transformers.ts
+++ b/src/services/transformers/work-packages.transformers.ts
@@ -1,0 +1,23 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { WorkPackage } from 'utils';
+import { descriptionBulletTransformer } from './projects.transformers';
+
+/**
+ * Transforms a work package to ensure deep field transformation of date objects.
+ *
+ * @param workPackage Incoming work package object supplied by the HTTP response.
+ * @returns Properly transformed work package object.
+ */
+export const workPackageTransformer = (workPackage: WorkPackage) => {
+  return {
+    ...workPackage,
+    dateCreated: new Date(workPackage.dateCreated),
+    startDate: new Date(workPackage.startDate),
+    expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
+    deliverables: workPackage.deliverables.map(descriptionBulletTransformer)
+  };
+};

--- a/src/services/users.api.ts
+++ b/src/services/users.api.ts
@@ -6,20 +6,7 @@
 import axios from 'axios';
 import { User } from 'utils';
 import { apiUrls } from '../shared/urls';
-
-/**
- * Transforms a user to ensure deep field transformation of date objects.
- *
- * @param user Incoming user object supplied by the HTTP response.
- * @returns Properly transformed user object.
- */
-export const userTransformer = (user: User) => {
-  return {
-    ...user,
-    firstLogin: new Date(user.firstLogin),
-    lastLogin: new Date(user.lastLogin)
-  };
-};
+import { userTransformer } from './transformers/users.transformers';
 
 /**
  * Fetches all users.

--- a/src/services/work-packages.api.ts
+++ b/src/services/work-packages.api.ts
@@ -7,23 +7,7 @@ import axios from 'axios';
 import { WbsNumber, WorkPackage } from 'utils';
 import { wbsPipe } from '../shared/pipes';
 import { apiUrls } from '../shared/urls';
-import { descriptionBulletTransformer } from './projects.api';
-
-/**
- * Transforms a work package to ensure deep field transformation of date objects.
- *
- * @param workPackage Incoming work package object supplied by the HTTP response.
- * @returns Properly transformed work package object.
- */
-export const workPackageTransformer = (workPackage: WorkPackage) => {
-  return {
-    ...workPackage,
-    dateCreated: new Date(workPackage.dateCreated),
-    startDate: new Date(workPackage.startDate),
-    expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
-    deliverables: workPackage.deliverables.map(descriptionBulletTransformer)
-  };
-};
+import { workPackageTransformer } from './transformers/work-packages.transformers';
 
 /**
  * Fetch all work packages.


### PR DESCRIPTION
We created a transformers folder and moved the change request transformer into it. We're not sure if we needed to do any tests for it because there weren't any previous tests for it. We are thinking about putting all transformer functions into one file.