### PR TITLE
#357 Project Shared Tools

### DIFF
--- a/src/backend/functions/projects.ts
+++ b/src/backend/functions/projects.ts
@@ -110,6 +110,7 @@ const projectTransformer = (
     otherConstraints: project.otherConstraints.map(descBulletConverter),
     features: project.features.map(descBulletConverter),
     goals: project.goals.map(descBulletConverter),
+    duration: project.workPackages.reduce((prev, curr) => prev + curr.duration, 0),
     workPackages: project.workPackages.map((workPackage) => {
       const endDate = new Date(workPackage.startDate);
       endDate.setDate(workPackage.duration * 7);

--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
@@ -4,7 +4,6 @@
  */
 
 import { ReactElement } from 'react';
-import { User } from '@prisma/client';
 import {
   ChangeRequest,
   StandardChangeRequest,
@@ -80,10 +79,10 @@ const buildActivationChangeRequestDetails = (cr: ActivationChangeRequest): React
       body={
         <dl className="row">
           <dt className="col-2">Project Lead</dt>
-          <dd className="col-3">{fullNamePipe((cr.projectLead as unknown) as User)}</dd>
+          <dd className="col-3">{fullNamePipe(cr.projectLead)}</dd>
           <div className="w-100"></div>
           <dt className="col-2">Project Manager</dt>
-          <dd className="col-3">{fullNamePipe((cr.projectManager as unknown) as User)}</dd>
+          <dd className="col-3">{fullNamePipe(cr.projectManager)}</dd>
           <div className="w-100"></div>
           <dt className="col-2">Start Date</dt>
           <dd className="col-3">{cr.startDate.toUTCString()}</dd>
@@ -140,7 +139,7 @@ const ChangeRequestDetails: React.FC<ChangeRequestDetailsProps> = ({
         body={
           <dl className="row">
             <dt className="col-2">Submitted</dt>
-            <dd className="col-2">{fullNamePipe((changeRequest.submitter as unknown) as User)}</dd>
+            <dd className="col-2">{fullNamePipe(changeRequest.submitter)}</dd>
             <dd className="col-3">{changeRequest.dateSubmitted.toUTCString()}</dd>
             <div className="w-100"></div>
             <dt className="col-2">Type</dt>

--- a/src/components/change-requests/change-requests-table/change-requests-table.tsx
+++ b/src/components/change-requests/change-requests-table/change-requests-table.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { User } from '@prisma/client';
 import { ChangeRequest } from 'utils';
 import { booleanPipe, fullNamePipe, wbsPipe } from '../../../shared/pipes';
 import { useAllChangeRequests } from '../../../services/change-requests.hooks';
@@ -24,7 +23,7 @@ const ChangeRequestsTable: React.FC = () => {
     return changeRequests.map((cr: ChangeRequest) => {
       return {
         id: cr.crId,
-        submitterName: fullNamePipe((cr.submitter as unknown) as User),
+        submitterName: fullNamePipe(cr.submitter),
         wbsNum: wbsPipe(cr.wbsNum),
         type: cr.type,
         dateReviewed: cr.dateReviewed ? new Date(cr.dateReviewed).toLocaleDateString() : '',

--- a/src/components/projects/projects-table/projects-table.test.tsx
+++ b/src/components/projects/projects-table/projects-table.test.tsx
@@ -4,21 +4,21 @@
  */
 
 import { UseQueryResult } from 'react-query';
-import { ProjectSummary } from 'utils';
+import { Project } from 'utils';
 import { wbsRegex, fireEvent, render, screen, waitFor } from '../../../test-support/test-utils';
 import { wbsPipe, fullNamePipe } from '../../../shared/pipes';
 import { useAllProjects } from '../../../services/projects.hooks';
-import { exampleAllProjectSummaries } from '../../../test-support/test-data/projects.stub';
+import { exampleAllProjects } from '../../../test-support/test-data/projects.stub';
 import { mockUseQueryResult } from '../../../test-support/test-data/test-utils.stub';
 import ProjectsTable from './projects-table';
 
 jest.mock('../../../services/projects.hooks');
 
-const mockedUseAllProjects = useAllProjects as jest.Mock<UseQueryResult<ProjectSummary[]>>;
+const mockedUseAllProjects = useAllProjects as jest.Mock<UseQueryResult<Project[]>>;
 
-const mockHook = (isLoading: boolean, isError: boolean, data?: ProjectSummary[], error?: Error) => {
+const mockHook = (isLoading: boolean, isError: boolean, data?: Project[], error?: Error) => {
   mockedUseAllProjects.mockReturnValue(
-    mockUseQueryResult<ProjectSummary[]>(isLoading, isError, data, error)
+    mockUseQueryResult<Project[]>(isLoading, isError, data, error)
   );
 };
 
@@ -62,30 +62,30 @@ describe('projects table component', () => {
   });
 
   it('handles the api returning a normal array of projects', async () => {
-    mockHook(false, false, exampleAllProjectSummaries);
+    mockHook(false, false, exampleAllProjects);
     renderComponent();
-    await waitFor(() => screen.getByText(wbsPipe(exampleAllProjectSummaries[0].wbsNum)));
+    await waitFor(() => screen.getByText(wbsPipe(exampleAllProjects[0].wbsNum)));
 
     expect(screen.getByText('5 weeks')).toBeInTheDocument();
     expect(
-      screen.getAllByText(fullNamePipe(exampleAllProjectSummaries[1].projectLead))[0]
+      screen.getAllByText(fullNamePipe(exampleAllProjects[1].projectLead))[0]
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(fullNamePipe(exampleAllProjectSummaries[0].projectManager))
-    ).toBeInTheDocument();
-    expect(screen.getByText(wbsPipe(exampleAllProjectSummaries[1].wbsNum))).toBeInTheDocument();
+    screen
+      .getAllByText(fullNamePipe(exampleAllProjects[0].projectManager))
+      .forEach((ele) => expect(ele).toBeInTheDocument());
+    expect(screen.getByText(wbsPipe(exampleAllProjects[1].wbsNum))).toBeInTheDocument();
 
     expect(screen.getByText('All Projects')).toBeInTheDocument();
     expect(screen.queryByText('No projects to display', { exact: false })).not.toBeInTheDocument();
   });
 
   it.skip('handles sorting and reverse sorting the table by wbs num', async () => {
-    mockHook(false, false, exampleAllProjectSummaries);
+    mockHook(false, false, exampleAllProjects);
     renderComponent();
-    await waitFor(() => screen.getByText(wbsPipe(exampleAllProjectSummaries[0].wbsNum)));
+    await waitFor(() => screen.getByText(wbsPipe(exampleAllProjects[0].wbsNum)));
 
     const column: string = 'WBS #';
-    const expectedWbsOrder: string[] = exampleAllProjectSummaries.map((prj) => wbsPipe(prj.wbsNum));
+    const expectedWbsOrder: string[] = exampleAllProjects.map((prj) => wbsPipe(prj.wbsNum));
 
     // Default sort is wbs ascending
     const wbsNumsAsc: HTMLElement[] = await screen.findAllByText(wbsRegex);

--- a/src/components/projects/projects-table/projects-table.tsx
+++ b/src/components/projects/projects-table/projects-table.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { ProjectSummary } from 'utils';
+import { Project } from 'utils';
 import { useAllProjects } from '../../../services/projects.hooks';
 import { weeksPipe, fullNamePipe, wbsPipe } from '../../../shared/pipes';
 import { DisplayProject } from './projects-table/projects-table';
@@ -19,7 +19,7 @@ const ProjectsTable: React.FC = () => {
 
   if (isError) return <ErrorPage message={error?.message} />;
 
-  const transformToDisplayProjects = (projects: ProjectSummary[]) => {
+  const transformToDisplayProjects = (projects: Project[]) => {
     return projects.map((prj) => {
       return {
         ...prj,

--- a/src/components/projects/projects-table/projects-table.tsx
+++ b/src/components/projects/projects-table/projects-table.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { User } from '@prisma/client';
 import { ProjectSummary } from 'utils';
 import { useAllProjects } from '../../../services/projects.hooks';
 import { weeksPipe, fullNamePipe, wbsPipe } from '../../../shared/pipes';
@@ -25,8 +24,8 @@ const ProjectsTable: React.FC = () => {
       return {
         ...prj,
         wbsNum: wbsPipe(prj.wbsNum),
-        projectLead: fullNamePipe((prj.projectLead as unknown) as User),
-        projectManager: fullNamePipe((prj.projectManager as unknown) as User),
+        projectLead: fullNamePipe(prj.projectLead),
+        projectManager: fullNamePipe(prj.projectManager),
         duration: weeksPipe(prj.duration)
       };
     }) as DisplayProject[];

--- a/src/components/projects/wbs-details/project-container/project-container.tsx
+++ b/src/components/projects/wbs-details/project-container/project-container.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsNumber, WorkPackageSummary as WorkPackageSum } from 'utils';
+import { WbsNumber, WorkPackageSummary as WPSummary } from 'utils';
 import { wbsPipe } from '../../../../shared/pipes';
 import { useSingleProject } from '../../../../services/projects.hooks';
 import ProjectDetails from './project-details/project-details';
@@ -42,7 +42,7 @@ const ProjectContainer: React.FC<ProjectContainerProps> = ({ wbsNum }: ProjectCo
         headerRight={<></>}
         body={
           <>
-            {data!.workPackages.map((ele: WorkPackageSum) => (
+            {data!.workPackages.map((ele: WPSummary) => (
               <div key={wbsPipe(ele.wbsNum)} className="mt-3">
                 <WorkPackageSummary workPackage={ele} />
               </div>

--- a/src/components/projects/wbs-details/project-container/project-container.tsx
+++ b/src/components/projects/wbs-details/project-container/project-container.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WorkPackage, WbsNumber } from 'utils';
+import { WbsNumber, WorkPackageSummary as WorkPackageSum } from 'utils';
 import { wbsPipe } from '../../../../shared/pipes';
 import { useSingleProject } from '../../../../services/projects.hooks';
 import ProjectDetails from './project-details/project-details';
@@ -42,7 +42,7 @@ const ProjectContainer: React.FC<ProjectContainerProps> = ({ wbsNum }: ProjectCo
         headerRight={<></>}
         body={
           <>
-            {data!.workPackages.map((ele: WorkPackage) => (
+            {data!.workPackages.map((ele: WorkPackageSum) => (
               <div key={wbsPipe(ele.wbsNum)} className="mt-3">
                 <WorkPackageSummary workPackage={ele} />
               </div>

--- a/src/components/projects/wbs-details/project-container/project-details/project-details.tsx
+++ b/src/components/projects/wbs-details/project-container/project-details/project-details.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { User } from '@prisma/client';
 import { Project } from 'utils';
 import {
   dollarsPipe,
@@ -31,10 +30,10 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ project }: ProjectDetai
           <b>WBS #:</b> {wbsPipe(project.wbsNum)}
         </p>
         <p>
-          <b>Project Lead:</b> {fullNamePipe((project.projectLead as unknown) as User)}
+          <b>Project Lead:</b> {fullNamePipe(project.projectLead)}
         </p>
         <p>
-          <b>Project Manager:</b> {fullNamePipe((project.projectManager as unknown) as User)}
+          <b>Project Manager:</b> {fullNamePipe(project.projectManager)}
         </p>
         <p>
           <b>Budget:</b> {dollarsPipe(project.budget)}

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
@@ -6,13 +6,13 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Collapse } from 'react-bootstrap';
-import { WorkPackageSummary as WorkPackageSum } from 'utils';
+import { WorkPackageSummary as WPSummary } from 'utils';
 import { weeksPipe, wbsPipe, endDatePipe, listPipe } from '../../../../../shared/pipes';
 import { routes } from '../../../../../shared/routes';
 import styles from './work-package-summary.module.css';
 
 interface WorkPackageSummaryProps {
-  workPackage: WorkPackageSum;
+  workPackage: WPSummary;
 }
 
 const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) => {

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
@@ -6,13 +6,13 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Collapse } from 'react-bootstrap';
-import { WorkPackage } from 'utils';
+import { WorkPackageSummary as WorkPackageSum } from 'utils';
 import { weeksPipe, wbsPipe, endDatePipe, listPipe } from '../../../../../shared/pipes';
 import { routes } from '../../../../../shared/routes';
 import styles from './work-package-summary.module.css';
 
 interface WorkPackageSummaryProps {
-  workPackage: WorkPackage;
+  workPackage: WorkPackageSum;
 }
 
 const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) => {

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
@@ -3,7 +3,6 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { User } from '@prisma/client';
 import { WorkPackage } from 'utils';
 import { weeksPipe, wbsPipe, endDatePipe, fullNamePipe } from '../../../../../shared/pipes';
 import PageBlock from '../../../../shared/page-block/page-block';
@@ -24,10 +23,10 @@ const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) 
           <b>WBS #:</b> {wbsPipe(workPackage.wbsNum)}
         </p>
         <p>
-          <b>Project Lead:</b> {fullNamePipe((workPackage.projectLead as unknown) as User)}
+          <b>Project Lead:</b> {fullNamePipe(workPackage.projectLead)}
         </p>
         <p>
-          <b>Project Manager:</b> {fullNamePipe((workPackage.projectManager as unknown) as User)}
+          <b>Project Manager:</b> {fullNamePipe(workPackage.projectManager)}
         </p>
         <p>
           <b>Duration:</b> {weeksPipe(workPackage.duration)}

--- a/src/services/projects.api.ts
+++ b/src/services/projects.api.ts
@@ -4,11 +4,10 @@
  */
 
 import axios from 'axios';
-import { DescriptionBullet, Project, ProjectSummary, WbsNumber } from 'utils';
+import { DescriptionBullet, Project, ProjectSummary, WbsNumber, WorkPackageSummary } from 'utils';
 import { wbsPipe } from '../shared/pipes';
 import { apiUrls } from '../shared/urls';
 import { userTransformer } from './users.api';
-import { workPackageTransformer } from './work-packages.api';
 
 /**
  * Transforms a description bullet to ensure deep field transformation of date objects.
@@ -34,7 +33,7 @@ const projectTransformer = (project: Project) => {
   return {
     ...project,
     dateCreated: new Date(project.dateCreated),
-    workPackages: project.workPackages.map(workPackageTransformer),
+    workPackages: project.workPackages.map(workPackageSummaryTransformer),
     goals: project.goals.map(descriptionBulletTransformer),
     features: project.features.map(descriptionBulletTransformer),
     otherConstraints: project.otherConstraints.map(descriptionBulletTransformer)
@@ -53,6 +52,14 @@ const projectSummaryTransformer = (projectSummary: ProjectSummary) => {
     projectLead: userTransformer(projectSummary.projectLead),
     projectManager: userTransformer(projectSummary.projectManager)
   } as ProjectSummary;
+};
+
+const workPackageSummaryTransformer = (workPackageSummary: WorkPackageSummary) => {
+  return {
+    ...workPackageSummary,
+    startDate: new Date(workPackageSummary.startDate),
+    endDate: new Date(workPackageSummary.endDate)
+  } as WorkPackageSummary;
 };
 
 /**

--- a/src/services/projects.api.ts
+++ b/src/services/projects.api.ts
@@ -4,10 +4,9 @@
  */
 
 import axios from 'axios';
-import { DescriptionBullet, Project, ProjectSummary, WbsNumber, WorkPackageSummary } from 'utils';
+import { DescriptionBullet, Project, WbsNumber, WorkPackageSummary } from 'utils';
 import { wbsPipe } from '../shared/pipes';
 import { apiUrls } from '../shared/urls';
-import { userTransformer } from './users.api';
 
 /**
  * Transforms a description bullet to ensure deep field transformation of date objects.
@@ -40,20 +39,6 @@ const projectTransformer = (project: Project) => {
   };
 };
 
-/**
- * Transforms a project summary to ensure deep field transformation of date objects.
- *
- * @param projectSummary Incoming project object supplied by the HTTP response.
- * @returns Properly transformed project object.
- */
-const projectSummaryTransformer = (projectSummary: ProjectSummary) => {
-  return {
-    ...projectSummary,
-    projectLead: userTransformer(projectSummary.projectLead),
-    projectManager: userTransformer(projectSummary.projectManager)
-  } as ProjectSummary;
-};
-
 const workPackageSummaryTransformer = (workPackageSummary: WorkPackageSummary) => {
   return {
     ...workPackageSummary,
@@ -66,8 +51,8 @@ const workPackageSummaryTransformer = (workPackageSummary: WorkPackageSummary) =
  * Fetches all projects.
  */
 export const getAllProjects = () => {
-  return axios.get<ProjectSummary[]>(apiUrls.projects(), {
-    transformResponse: (data) => JSON.parse(data).map(projectSummaryTransformer)
+  return axios.get<Project[]>(apiUrls.projects(), {
+    transformResponse: (data) => JSON.parse(data).map(projectTransformer)
   });
 };
 

--- a/src/services/projects.hooks.ts
+++ b/src/services/projects.hooks.ts
@@ -4,14 +4,14 @@
  */
 
 import { useQuery } from 'react-query';
-import { Project, ProjectSummary, WbsNumber } from 'utils';
+import { Project, WbsNumber } from 'utils';
 import { getAllProjects, getSingleProject } from './projects.api';
 
 /**
  * Custom React Hook to supply all projects.
  */
 export const useAllProjects = () => {
-  return useQuery<ProjectSummary[], Error>('projects', async () => {
+  return useQuery<Project[], Error>('projects', async () => {
     const { data } = await getAllProjects();
     return data;
   });

--- a/src/shared/pipes.tsx
+++ b/src/shared/pipes.tsx
@@ -14,8 +14,8 @@ import { WbsNumber } from 'utils';
  * Pipe is a term / tool from Angular.
  */
 
-export const linkPipe = (description: string, link: string): ReactElement => {
-  return <a href={link}>{description}</a>;
+export const linkPipe = (description: string, link?: string): ReactElement => {
+  return link ? <a href={link}>{description}</a> : <>{description}</>;
 };
 
 export const weeksPipe = (weeks: number): string => {
@@ -30,8 +30,8 @@ export const wbsPipe = (wbsNum: WbsNumber): string => {
   return `${wbsNum.car}.${wbsNum.project}.${wbsNum.workPackage}`;
 };
 
-export const fullNamePipe = (user: User): string => {
-  return `${user.firstName} ${user.lastName}`;
+export const fullNamePipe = (user?: User): string => {
+  return user ? `${user.firstName} ${user.lastName}` : emDashPipe();
 };
 
 export const booleanPipe = (bool: boolean): string => {
@@ -51,13 +51,13 @@ export const endDatePipe = (startDate: Date, durWeeks: number): string => {
 };
 
 // Returns an empty string if a passed in string is empty, otherwise return the given string
-export const emptyStringPipe = (str: string): string => {
-  return str === undefined || str === null ? '' : str;
+export const emptyStringPipe = (str?: string): string => {
+  return str ?? '';
 };
 
 // Replace an empty string with an EM dash
-export const emDashPipe = (str: string): string => {
-  return str === undefined || str === null ? '—' : str;
+export const emDashPipe = (str?: string): string => {
+  return str ?? '—';
 };
 
 // return a given data as a string in the local en-US format

--- a/src/test-support/test-data/projects.stub.ts
+++ b/src/test-support/test-data/projects.stub.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Project, ProjectSummary } from 'utils';
+import { Project } from 'utils';
 import { WbsElementStatus } from 'utils/src';
 import {
   exampleAdminUser,
@@ -62,6 +62,7 @@ export const exampleProject1: Project = {
       detail: 'Added goal for weight reduction'
     }
   ],
+  duration: 8,
   workPackages: [exampleWorkPackage1, exampleWorkPackage2]
 };
 
@@ -97,6 +98,7 @@ export const exampleProject2: Project = {
     { id: 11, detail: 'Compatible with a side-pod chassis design', dateAdded: new Date('06/12/21') }
   ],
   changes: [],
+  duration: 0,
   workPackages: []
 };
 
@@ -136,6 +138,7 @@ export const exampleProject3: Project = {
     }
   ],
   changes: [],
+  duration: 3,
   workPackages: [exampleWorkPackage1]
 };
 
@@ -171,6 +174,7 @@ export const exampleProject4: Project = {
     { id: 13, detail: 'Must be compatible with chain drive', dateAdded: new Date('05/12/21') }
   ],
   changes: [],
+  duration: 5,
   workPackages: [exampleWorkPackage2]
 };
 
@@ -206,6 +210,7 @@ export const exampleProject5: Project = {
     { id: 14, detail: 'Utilizes 8020 frame construction', dateAdded: new Date('02/16/21') }
   ],
   changes: [],
+  duration: 2,
   workPackages: [exampleWorkPackage3]
 };
 
@@ -215,27 +220,4 @@ export const exampleAllProjects: Project[] = [
   exampleProject3,
   exampleProject4,
   exampleProject5
-];
-
-export const exampleProjectSummary1: ProjectSummary = {
-  wbsNum: exampleWbsProject1,
-  name: 'Project Summary 1',
-  projectLead: exampleAdminUser,
-  projectManager: exampleProjectManagerUser,
-  duration: 5,
-  status: WbsElementStatus.Active
-};
-
-export const exampleProjectSummary2: ProjectSummary = {
-  wbsNum: exampleWbsProject2,
-  name: 'Project Summary 2',
-  projectLead: exampleProjectLeadUser,
-  projectManager: exampleLeadershipUser,
-  duration: 17,
-  status: WbsElementStatus.Complete
-};
-
-export const exampleAllProjectSummaries: ProjectSummary[] = [
-  exampleProjectSummary1,
-  exampleProjectSummary2
 ];

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -36,6 +36,7 @@ export interface Project extends WbsElement {
   slideDeckLink?: string;
   bomLink?: string;
   rules: string[];
+  duration: number;
   goals: DescriptionBullet[];
   features: DescriptionBullet[];
   otherConstraints: DescriptionBullet[];
@@ -68,13 +69,4 @@ export interface DescriptionBullet {
   detail: string;
   dateAdded: Date;
   dateDeleted?: Date;
-}
-
-export interface ProjectSummary {
-  wbsNum: WbsNumber;
-  name: string;
-  projectLead: User;
-  projectManager: User;
-  duration: number;
-  status: WbsElementStatus;
 }

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -31,15 +31,25 @@ export enum WbsElementStatus {
 
 export interface Project extends WbsElement {
   budget: number;
-  gDriveLink: string;
-  taskListLink: string;
-  slideDeckLink: string;
-  bomLink: string;
+  gDriveLink?: string;
+  taskListLink?: string;
+  slideDeckLink?: string;
+  bomLink?: string;
   rules: string[];
   goals: DescriptionBullet[];
   features: DescriptionBullet[];
   otherConstraints: DescriptionBullet[];
-  workPackages: WorkPackage[];
+  workPackages: WorkPackageSummary[];
+}
+
+export interface WorkPackageSummary {
+  id: number;
+  wbsNum: WbsNumber;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  duration: number;
+  dependencies: WbsNumber[];
 }
 
 export interface WorkPackage extends WbsElement {


### PR DESCRIPTION
Closes #357

We have added the projects transformer and updated the types to align the database and interfaces a bit more. We added a workPackageSummary type to replace the workPackage type on Projects, so projects is not transforming work packages and everything in them as well.