### PR TITLE
dark mode first attempt, mostly just the context, also settings page

### DIFF
--- a/src/components/app/app-context-settings/app-context-settings.module.css
+++ b/src/components/app/app-context-settings/app-context-settings.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/components/app/app-context-settings/app-context-settings.test.tsx
+++ b/src/components/app/app-context-settings/app-context-settings.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render, screen } from '@testing-library/react'; // avoid circular dependency
+import AppContextSettings from './app-context-settings';
+import { useSettings } from '../../../services/settings.hooks';
+
+describe('app context auth', () => {
+  it('renders simple text as children', () => {
+    render(<AppContextSettings>hello</AppContextSettings>);
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('provides the settings object to child components', () => {
+    const TestComponent = () => {
+      const settings = useSettings();
+      return <p>test: {settings.darkMode ? 'dark' : 'light'}</p>;
+    };
+    render(
+      <AppContextSettings>
+        <TestComponent />
+      </AppContextSettings>
+    );
+    expect(screen.getByText(/test:/)).toBeInTheDocument();
+    expect(screen.getByText(/light/)).toBeInTheDocument();
+  });
+});

--- a/src/components/app/app-context-settings/app-context-settings.tsx
+++ b/src/components/app/app-context-settings/app-context-settings.tsx
@@ -1,0 +1,18 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { createContext } from 'react';
+import { useProvideSettings } from '../../../services/settings.hooks';
+import { Settings } from '../../../shared/types';
+import './app-context-settings.module.css';
+
+export const SettingsContext = createContext<Settings | undefined>(undefined);
+
+const AppContextSettings: React.FC = (props) => {
+  const settings = useProvideSettings();
+  return <SettingsContext.Provider value={settings}>{props.children}</SettingsContext.Provider>;
+};
+
+export default AppContextSettings;

--- a/src/components/app/app-context/app-context.test.tsx
+++ b/src/components/app/app-context/app-context.test.tsx
@@ -24,6 +24,15 @@ jest.mock('../app-context-auth/app-context-auth', () => {
   };
 });
 
+jest.mock('../app-context-settings/app-context-settings', () => {
+  return {
+    __esModule: true,
+    default: (props: any) => {
+      return <div>app context settings {props.children}</div>;
+    }
+  };
+});
+
 // Sets up the component under test with the desired values and renders it
 const renderComponent = () => {
   render(
@@ -42,6 +51,11 @@ describe('app context', () => {
   it('renders the app context auth component', () => {
     renderComponent();
     expect(screen.getByText('app context auth')).toBeInTheDocument();
+  });
+
+  it('renders the app context settings component', () => {
+    renderComponent();
+    expect(screen.getByText('app context settings')).toBeInTheDocument();
   });
 
   it('renders the app context text', () => {

--- a/src/components/app/app-context/app-context.tsx
+++ b/src/components/app/app-context/app-context.tsx
@@ -5,12 +5,15 @@
 
 import AppContextAuth from '../app-context-auth/app-context-auth';
 import AppContextQuery from '../app-context-query/app-context-query';
+import AppContextSettings from '../app-context-settings/app-context-settings';
 import './app-context.module.css';
 
 const AppContext: React.FC = (props) => {
   return (
     <AppContextQuery>
-      <AppContextAuth>{props.children}</AppContextAuth>
+      <AppContextAuth>
+        <AppContextSettings>{props.children}</AppContextSettings>
+      </AppContextAuth>
     </AppContextQuery>
   );
 };

--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.test.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.test.tsx
@@ -17,13 +17,22 @@ import {
   exampleStageGateChangeRequest,
   exampleAllChangeRequests
 } from '../../../../test-support/test-data/change-requests.stub';
+import AppContext from '../../../app/app-context/app-context';
 import ChangeRequestDetails from './change-request-details';
+
+const renderComponent = (cr: ChangeRequest) => {
+  render(
+    <AppContext>
+      <ChangeRequestDetails changeRequest={cr} />
+    </AppContext>
+  );
+};
 
 describe('Change request details common display element tests', () => {
   it.each(exampleAllChangeRequests.map((testCr: ChangeRequest) => [testCr]))(
     'Renders the title for CR %#',
     (cr: ChangeRequest) => {
-      render(<ChangeRequestDetails changeRequest={cr} />);
+      renderComponent(cr);
       expect(screen.getByText(`Change Request #${cr.id}`)).toBeInTheDocument();
     }
   );
@@ -31,7 +40,7 @@ describe('Change request details common display element tests', () => {
   it.each(exampleAllChangeRequests.map((testCr: ChangeRequest) => [testCr]))(
     'Renders submitter data for CR %#',
     (cr: ChangeRequest) => {
-      render(<ChangeRequestDetails changeRequest={cr} />);
+      renderComponent(cr);
       expect(screen.getByText(`Submitted`)).toBeInTheDocument();
       expect(
         screen.getByText(`${cr.submitter.firstName} ${cr.submitter.lastName}`)
@@ -43,7 +52,7 @@ describe('Change request details common display element tests', () => {
   it.each(exampleAllChangeRequests.map((testCr: ChangeRequest) => [testCr]))(
     'Renders type data for CR %#',
     (cr: ChangeRequest) => {
-      render(<ChangeRequestDetails changeRequest={cr} />);
+      renderComponent(cr);
       expect(screen.getByText(`Type`)).toBeInTheDocument();
       expect(screen.getByText(`${cr.type}`)).toBeInTheDocument();
     }
@@ -52,7 +61,7 @@ describe('Change request details common display element tests', () => {
   it.each(exampleAllChangeRequests.map((testCr: ChangeRequest) => [testCr]))(
     'Renders status data for CR %#',
     (cr: ChangeRequest) => {
-      render(<ChangeRequestDetails changeRequest={cr} />);
+      renderComponent(cr);
       if (cr.dateImplemented) {
         expect(screen.getByText(`Implemented`)).toBeInTheDocument();
       }
@@ -71,7 +80,7 @@ describe('Change request details common display element tests', () => {
   it.each(exampleAllChangeRequests.map((testCr: ChangeRequest) => [testCr]))(
     'Renders changes data for CR %#',
     (cr: ChangeRequest) => {
-      render(<ChangeRequestDetails changeRequest={cr} />);
+      renderComponent(cr);
       expect(screen.getByText(`Implemented Changes`)).toBeInTheDocument();
       expect(screen.getByText(`list of changes`)).toBeInTheDocument();
     }
@@ -80,13 +89,13 @@ describe('Change request details common display element tests', () => {
 
 describe('Change request details standard cr display element tests', () => {
   it('Renders what section', () => {
-    render(<ChangeRequestDetails changeRequest={exampleStandardChangeRequest} />);
+    renderComponent(exampleStandardChangeRequest);
     expect(screen.getByText(`What`)).toBeInTheDocument();
     expect(screen.getByText(`${exampleStandardChangeRequest.what}`)).toBeInTheDocument();
   });
 
   it('Renders why section', () => {
-    render(<ChangeRequestDetails changeRequest={exampleStandardChangeRequest} />);
+    renderComponent(exampleStandardChangeRequest);
     expect(screen.getByText(`Why`)).toBeInTheDocument();
     exampleStandardChangeRequest.why.forEach((explanation: ChangeRequestExplanation) => {
       expect(screen.getByText(`${explanation.reason}`)).toBeInTheDocument();
@@ -96,7 +105,7 @@ describe('Change request details standard cr display element tests', () => {
 
   it('Renders impact section', () => {
     const cr: StandardChangeRequest = exampleStandardChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Impact`)).toBeInTheDocument();
     expect(screen.getByText(`Scope Impact`)).toBeInTheDocument();
     expect(screen.getByText(`${cr.scopeImpact}`)).toBeInTheDocument();
@@ -110,7 +119,7 @@ describe('Change request details standard cr display element tests', () => {
 describe('Change request details activation cr display element tests', () => {
   it('Renders project lead', () => {
     const cr: ActivationChangeRequest = exampleActivationChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Project Lead`)).toBeInTheDocument();
     expect(
       screen.getByText(`${cr.projectLead.firstName} ${cr.projectLead.lastName}`)
@@ -119,7 +128,7 @@ describe('Change request details activation cr display element tests', () => {
 
   it('Renders project manager', () => {
     const cr: ActivationChangeRequest = exampleActivationChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Project Manager`)).toBeInTheDocument();
     expect(
       screen.getByText(`${cr.projectManager.firstName} ${cr.projectManager.lastName}`)
@@ -128,14 +137,14 @@ describe('Change request details activation cr display element tests', () => {
 
   it('Renders start date', () => {
     const cr: ActivationChangeRequest = exampleActivationChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Start Date`)).toBeInTheDocument();
     expect(screen.getByText(`${cr.dateSubmitted.toUTCString()}`)).toBeInTheDocument();
   });
 
   it('Renders confirm details', () => {
     const cr: ActivationChangeRequest = exampleActivationChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Confirm WP Details`)).toBeInTheDocument();
     expect(screen.getByText(`${cr.confirmDetails ? 'YES' : 'NO'}`)).toBeInTheDocument();
   });
@@ -144,14 +153,14 @@ describe('Change request details activation cr display element tests', () => {
 describe('Change request details stage gate cr display element tests', () => {
   it('Renders confirm completed', () => {
     const cr: StageGateChangeRequest = exampleStageGateChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Confirm WP Completed`)).toBeInTheDocument();
     expect(screen.getByText(`${cr.confirmCompleted ? 'YES' : 'NO'}`)).toBeInTheDocument();
   });
 
   it('Renders leftover budget', () => {
     const cr: StageGateChangeRequest = exampleStageGateChangeRequest;
-    render(<ChangeRequestDetails changeRequest={cr} />);
+    renderComponent(cr);
     expect(screen.getByText(`Leftover Budget`)).toBeInTheDocument();
     expect(screen.getByText(`$${cr.leftoverBudget}`)).toBeInTheDocument();
   });

--- a/src/components/projects/wbs-details/project-container/project-details/project-details.test.tsx
+++ b/src/components/projects/wbs-details/project-container/project-details/project-details.test.tsx
@@ -10,23 +10,36 @@ import {
   exampleProject2,
   exampleProject3
 } from '../../../../../test-support/test-data/projects.stub';
+import AppContext from '../../../../app/app-context/app-context';
 import ProjectDetails from './project-details';
 
 describe('project details component', () => {
   it('Renders title', () => {
-    render(<ProjectDetails project={exampleProject1} />);
+    render(
+      <AppContext>
+        <ProjectDetails project={exampleProject1} />
+      </AppContext>
+    );
     const titleElement = screen.getByText('Project Details');
     expect(titleElement).toBeInTheDocument();
   });
 
   it('Renders WBS#', () => {
-    render(<ProjectDetails project={exampleProject2} />);
+    render(
+      <AppContext>
+        <ProjectDetails project={exampleProject2} />
+      </AppContext>
+    );
     const projectElement = screen.getByText(wbsPipe(exampleProject2.wbsNum), { exact: false });
     expect(projectElement).toBeInTheDocument();
   });
 
   it('Renders project lead', () => {
-    render(<ProjectDetails project={exampleProject3} />);
+    render(
+      <AppContext>
+        <ProjectDetails project={exampleProject3} />
+      </AppContext>
+    );
     const projectNameElement = screen.getByText(
       listPipe(exampleProject3.projectLead, fullNamePipe),
       {

--- a/src/components/projects/wbs-details/project-container/rules-list/rules-list.test.tsx
+++ b/src/components/projects/wbs-details/project-container/rules-list/rules-list.test.tsx
@@ -5,17 +5,26 @@
 
 import { render, screen } from '@testing-library/react';
 import { exampleProject1 } from '../../../../../test-support/test-data/projects.stub';
+import AppContext from '../../../../app/app-context/app-context';
 import RulesList from './rules-list';
 
 describe('Rendering Work Package Rules Component', () => {
   it('renders the component title', () => {
-    render(<RulesList rules={exampleProject1.rules} />);
+    render(
+      <AppContext>
+        <RulesList rules={exampleProject1.rules} />
+      </AppContext>
+    );
 
     expect(screen.getByText(`Rules`)).toBeInTheDocument();
   });
 
   it('renders all the listed rules', () => {
-    render(<RulesList rules={exampleProject1.rules} />);
+    render(
+      <AppContext>
+        <RulesList rules={exampleProject1.rules} />
+      </AppContext>
+    );
 
     expect(screen.getByText('EV3.5.2')).toBeInTheDocument();
   });

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.test.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.test.tsx
@@ -11,12 +11,17 @@ import {
   exampleWorkPackage2,
   exampleWorkPackage3
 } from '../../../../../test-support/test-data/work-packages.stub';
+import AppContext from '../../../../app/app-context/app-context';
 import WorkPackageDetails from './work-package-details';
 
 describe('Rendering Work Packagae Details Component', () => {
   it('renders all the fields, example 1', () => {
     const wp: WorkPackage = exampleWorkPackage1;
-    render(<WorkPackageDetails workPackage={wp} />);
+    render(
+      <AppContext>
+        <WorkPackageDetails workPackage={wp} />
+      </AppContext>
+    );
     expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
     expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
@@ -39,7 +44,11 @@ describe('Rendering Work Packagae Details Component', () => {
 
   it('renders all the fields, example 2', () => {
     const wp: WorkPackage = exampleWorkPackage2;
-    render(<WorkPackageDetails workPackage={wp} />);
+    render(
+      <AppContext>
+        <WorkPackageDetails workPackage={wp} />
+      </AppContext>
+    );
     expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
     expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();
@@ -62,7 +71,11 @@ describe('Rendering Work Packagae Details Component', () => {
 
   it('renders all the fields, example 3', () => {
     const wp: WorkPackage = exampleWorkPackage3;
-    render(<WorkPackageDetails workPackage={wp} />);
+    render(
+      <AppContext>
+        <WorkPackageDetails workPackage={wp} />
+      </AppContext>
+    );
     expect(screen.getByText(`Work Package Details`)).toBeInTheDocument();
     expect(screen.getByText(`${wp.status}`, { exact: false })).toBeInTheDocument();
     expect(screen.getByText(`${wp.name}`, { exact: false })).toBeInTheDocument();

--- a/src/components/settings/settings.test.tsx
+++ b/src/components/settings/settings.test.tsx
@@ -25,8 +25,16 @@ describe('settings page component', () => {
     expect(screen.getByText('This is the Settings Page')).toBeInTheDocument();
   });
 
-  it('renders user', () => {
+  it('renders user details', () => {
     renderComponent();
-    expect(screen.getByText('User:')).toBeInTheDocument();
+    expect(screen.getByText(/User:/)).toBeInTheDocument();
+    expect(screen.getByText(/First Name:/)).toBeInTheDocument();
+    expect(screen.getByText(/Last Name:/)).toBeInTheDocument();
+    expect(screen.getByText(/Email:/)).toBeInTheDocument();
+  });
+
+  it('renders settings', () => {
+    renderComponent();
+    expect(screen.getByText(/Dark Mode:/)).toBeInTheDocument();
   });
 });

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -17,7 +17,7 @@ const Settings: React.FC = () => {
     <>
       <PageTitle title="This is the Settings Page" />
       <PageBlock
-        title="User Settings"
+        title="User Details"
         headerRight={<></>}
         body={
           <>
@@ -28,7 +28,14 @@ const Settings: React.FC = () => {
             Last Name: {auth.user?.lastName}
             <br />
             Email: {auth.user?.emailId}
-            <br />
+          </>
+        }
+      />
+      <PageBlock
+        title="User Settings"
+        headerRight={<></>}
+        body={
+          <>
             Dark Mode: {settings.darkMode ? 'Enabled' : 'Disabled'}
             <Button className={'mx-2'} size={'sm'} onClick={settings.toggleDarkMode}>
               Toggle Dark Mode

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -3,18 +3,33 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { useSettings } from '../../services/settings.hooks';
 import { useAuth } from '../../services/auth.hooks';
 import PageTitle from '../shared/page-title/page-title';
 import PageBlock from '../shared/page-block/page-block';
 import './settings.module.css';
+import { Button } from 'react-bootstrap';
 
 const Settings: React.FC = () => {
   const auth = useAuth();
-  const pageBlockBody = <>User: {auth.user?.emailId}</>;
+  const settings = useSettings();
   return (
     <>
       <PageTitle title="This is the Settings Page" />
-      <PageBlock title="User Settings" headerRight={<></>} body={pageBlockBody} />
+      <PageBlock
+        title="User Settings"
+        headerRight={<></>}
+        body={
+          <>
+            User: {auth.user?.emailId}
+            <br />
+            Dark Mode: {settings.darkMode ? 'Enabled' : 'Disabled'}
+            <Button className={'mx-2'} size={'sm'} onClick={settings.toggleDarkMode}>
+              Toggle Dark Mode
+            </Button>
+          </>
+        }
+      />
     </>
   );
 };

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -23,6 +23,12 @@ const Settings: React.FC = () => {
           <>
             User: {auth.user?.emailId}
             <br />
+            First Name: {auth.user?.firstName}
+            <br />
+            Last Name: {auth.user?.lastName}
+            <br />
+            Email: {auth.user?.emailId}
+            <br />
             Dark Mode: {settings.darkMode ? 'Enabled' : 'Disabled'}
             <Button className={'mx-2'} size={'sm'} onClick={settings.toggleDarkMode}>
               Toggle Dark Mode

--- a/src/components/shared/bullet-list/bullet-list.test.tsx
+++ b/src/components/shared/bullet-list/bullet-list.test.tsx
@@ -4,24 +4,37 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import AppContext from '../../app/app-context/app-context';
 import BulletList from './bullet-list';
 
 describe('Bullet List Component', () => {
   it('renders the component title', () => {
-    render(<BulletList title={'test'} headerRight={<></>} list={[<></>]} />);
+    render(
+      <AppContext>
+        <BulletList title={'test'} headerRight={<></>} list={[<></>]} />
+      </AppContext>
+    );
 
     expect(screen.getByText('test')).toBeInTheDocument();
   });
 
   it('renders all bullets', () => {
-    render(<BulletList title={'test'} headerRight={<></>} list={[<>one</>, <>two</>]} />);
+    render(
+      <AppContext>
+        <BulletList title={'test'} headerRight={<></>} list={[<>one</>, <>two</>]} />
+      </AppContext>
+    );
 
     expect(screen.getByText('one')).toBeInTheDocument();
     expect(screen.getByText('two')).toBeInTheDocument();
   });
 
   it('renders ordered list', () => {
-    render(<BulletList title={'test'} headerRight={<></>} list={[<>one</>, <>two</>]} ordered />);
+    render(
+      <AppContext>
+        <BulletList title={'test'} headerRight={<></>} list={[<>one</>, <>two</>]} ordered />
+      </AppContext>
+    );
 
     expect(screen.getByText('one')).toBeInTheDocument();
     expect(screen.getByText('two')).toBeInTheDocument();

--- a/src/components/shared/description-list/description-list.test.tsx
+++ b/src/components/shared/description-list/description-list.test.tsx
@@ -5,19 +5,26 @@
 
 import { render, screen } from '@testing-library/react';
 import { exampleWorkPackage2 } from '../../../test-support/test-data/work-packages.stub';
+import AppContext from '../../app/app-context/app-context';
 import DescriptionList from './description-list';
 
 describe('Rendering Description List Component', () => {
   it('renders the component title', () => {
     render(
-      <DescriptionList title={'Description'} items={exampleWorkPackage2.expectedActivities} />
+      <AppContext>
+        <DescriptionList title={'Description'} items={exampleWorkPackage2.expectedActivities} />
+      </AppContext>
     );
 
     expect(screen.getByText('Description')).toBeInTheDocument();
   });
 
   it('renders all bullets', () => {
-    render(<DescriptionList title={'test'} items={exampleWorkPackage2.expectedActivities} />);
+    render(
+      <AppContext>
+        <DescriptionList title={'test'} items={exampleWorkPackage2.expectedActivities} />
+      </AppContext>
+    );
 
     expect(
       screen.getByText(

--- a/src/components/shared/horizontal-list/horizontal-list.test.tsx
+++ b/src/components/shared/horizontal-list/horizontal-list.test.tsx
@@ -4,17 +4,26 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import AppContext from '../../app/app-context/app-context';
 import HorizontalList from './horizontal-list';
 
 describe('Horizontal List Component', () => {
   it('renders the title', () => {
-    render(<HorizontalList title={'test'} headerRight={<></>} items={[<>one</>, <>two</>]} />);
+    render(
+      <AppContext>
+        <HorizontalList title={'test'} headerRight={<></>} items={[<>one</>, <>two</>]} />
+      </AppContext>
+    );
 
     expect(screen.getByText('test')).toBeInTheDocument();
   });
 
   it('renders all the listed items', () => {
-    render(<HorizontalList title={'test'} headerRight={<></>} items={[<>one</>, <>two</>]} />);
+    render(
+      <AppContext>
+        <HorizontalList title={'test'} headerRight={<></>} items={[<>one</>, <>two</>]} />
+      </AppContext>
+    );
 
     expect(screen.getByText('one')).toBeInTheDocument();
     expect(screen.getByText('two')).toBeInTheDocument();

--- a/src/components/shared/page-block/page-block.module.css
+++ b/src/components/shared/page-block/page-block.module.css
@@ -17,3 +17,7 @@
 .headerRight {
   float: right;
 }
+
+.lightText {
+  color: white;
+}

--- a/src/components/shared/page-block/page-block.test.tsx
+++ b/src/components/shared/page-block/page-block.test.tsx
@@ -4,10 +4,15 @@
  */
 
 import { render } from '@testing-library/react';
+import AppContext from '../../app/app-context/app-context';
 import PageBlock from './page-block';
 
 const renderComponent = () => {
-  return render(<PageBlock title={'test'} headerRight={<>hi</>} body={<>hello</>} />);
+  return render(
+    <AppContext>
+      <PageBlock title={'test'} headerRight={<>hi</>} body={<>hello</>} />
+    </AppContext>
+  );
 };
 
 describe('card component', () => {

--- a/src/components/shared/page-block/page-block.tsx
+++ b/src/components/shared/page-block/page-block.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Card } from 'react-bootstrap';
+import { useSettings } from '../../../services/settings.hooks';
 import styles from './page-block.module.css';
 
 interface PageBlockProps {
@@ -14,8 +15,13 @@ interface PageBlockProps {
 
 // Custom card component for page blocks
 const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, body }) => {
+  const settings = useSettings();
   return (
-    <Card className={'mx-4 my-3'} border="dark" bg="light">
+    <Card
+      className={'mx-4 my-3'}
+      border={settings.darkMode ? 'light' : 'dark'}
+      bg={settings.darkMode ? 'dark' : 'light'}
+    >
       <Card.Body>
         <Card.Title className={styles.header}>
           <div className={styles.title}>{title}</div>

--- a/src/components/shared/page-block/page-block.tsx
+++ b/src/components/shared/page-block/page-block.tsx
@@ -18,7 +18,7 @@ const PageBlock: React.FC<PageBlockProps> = ({ title, headerRight, body }) => {
   const settings = useSettings();
   return (
     <Card
-      className={'mx-4 my-3'}
+      className={'mx-4 my-3 ' + (settings.darkMode ? styles.lightText : '')}
       border={settings.darkMode ? 'light' : 'dark'}
       bg={settings.darkMode ? 'dark' : 'light'}
     >

--- a/src/services/settings.hooks.ts
+++ b/src/services/settings.hooks.ts
@@ -1,0 +1,29 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useState, useContext } from 'react';
+import { SettingsContext } from '../components/app/app-context-settings/app-context-settings';
+import { Settings } from '../shared/types';
+
+// Provider hook that creates settings object and handles state
+export const useProvideSettings = () => {
+  const [darkMode, setDarkMode] = useState<boolean>(false);
+
+  const toggleDarkMode = () => {
+    setDarkMode(!darkMode);
+  };
+
+  return {
+    darkMode,
+    toggleDarkMode
+  } as Settings;
+};
+
+// Hook for child components to get the settings object
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (context === undefined) throw Error('Settings must be used inside of context.');
+  return context;
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,3 +11,8 @@ export interface Auth {
   signin: (token: string) => Promise<User>;
   signout: () => void;
 }
+
+export interface Settings {
+  darkMode: boolean;
+  toggleDarkMode: () => void;
+}


### PR DESCRIPTION
Very half-assed initial stab at getting dark mode working. I think we should not pursue this until after #388 gets closed and we discuss the approach a bit. We'll definitely need design support on this so we don't end up making a shitty ugly dark mode. I suspect the context I've implemented here will stay, since it offers flexibility to implement a lot of other global client-side settings, which could later be implemented as saved settings by linking them to the back-end. Also I made adjustments to the settings page.

Here's the new settings page
<img width="1480" alt="Screen Shot 2021-12-16 at 3 04 12 AM" src="https://user-images.githubusercontent.com/51571627/146331855-9a6ba2aa-6c55-43d2-8f72-129204807936.png">
 

Here's the dark mode attempt:
<img width="1472" alt="Screen Shot 2021-12-16 at 3 04 56 AM" src="https://user-images.githubusercontent.com/51571627/146331963-205b9a0b-e624-40d3-ba89-00cba9bc1a82.png">
<img width="1463" alt="Screen Shot 2021-12-16 at 3 05 37 AM" src="https://user-images.githubusercontent.com/51571627/146332064-1176518c-b15b-414c-be54-a605ddb2e7a4.png">

