### PR TITLE
sidebar attempt #2

### DIFF
--- a/src/components/app/app-authenticated/app-authenticated.module.css
+++ b/src/components/app/app-authenticated/app-authenticated.module.css
@@ -4,5 +4,5 @@
  */
 
 .content {
-  margin-top: 5em;
+  width: 100%;
 }

--- a/src/components/app/app-authenticated/app-authenticated.tsx
+++ b/src/components/app/app-authenticated/app-authenticated.tsx
@@ -12,19 +12,23 @@ import Home from '../../home/home';
 import NavTopBar from '../../whole-app/nav-top-bar/nav-top-bar';
 import Settings from '../../settings/settings';
 import styles from './app-authenticated.module.css';
+import Sidebar from '../../whole-app/sidebar/sidebar';
 
 const AppAuthenticated: React.FC = () => {
   return (
     <>
       <NavTopBar />
-      <div className={styles.content}>
-        <Switch>
-          <Route path={routes.PROJECTS} component={Projects} />
-          <Route path={routes.CHANGE_REQUESTS} component={ChangeRequests} />
-          <Route path={routes.SETTINGS} component={Settings} />
-          <Route exact path={routes.HOME} component={Home} />
-          <Route path="*" component={PageNotFound} />
-        </Switch>
+      <div className={'d-flex'}>
+        <Sidebar />
+        <div className={styles.content}>
+          <Switch>
+            <Route path={routes.PROJECTS} component={Projects} />
+            <Route path={routes.CHANGE_REQUESTS} component={ChangeRequests} />
+            <Route path={routes.SETTINGS} component={Settings} />
+            <Route exact path={routes.HOME} component={Home} />
+            <Route path="*" component={PageNotFound} />
+          </Switch>
+        </div>
       </div>
     </>
   );

--- a/src/components/whole-app/nav-top-bar/nav-top-bar.test.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-top-bar.test.tsx
@@ -23,11 +23,4 @@ describe('navigation top bar tests', () => {
     renderComponent();
     expect(screen.getByText(/NER PM Dashboard/i)).toBeInTheDocument();
   });
-
-  it('renders navigation links', () => {
-    renderComponent();
-    expect(screen.getByText(/Home/i)).toBeInTheDocument();
-    expect(screen.getByText(/Projects/i)).toBeInTheDocument();
-    expect(screen.getByText(/Changes/i)).toBeInTheDocument();
-  });
 });

--- a/src/components/whole-app/nav-top-bar/nav-top-bar.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-top-bar.tsx
@@ -7,7 +7,6 @@ import { Navbar, Nav } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { routes } from '../../../shared/routes';
 import NavUserMenu from './nav-user-menu/nav-user-menu';
-import NavPageLinks from './nav-page-links/nav-page-links';
 import NavNotificationsMenu from './nav-notifications-menu/nav-notifications-menu';
 import styles from './nav-top-bar.module.css';
 
@@ -28,7 +27,6 @@ const NavTopBar: React.FC = () => {
       <Navbar.Collapse id="nav-top-bar-items">
         <Nav className="ml-auto">
           <NavNotificationsMenu />
-          <NavPageLinks />
           <NavUserMenu />
         </Nav>
       </Navbar.Collapse>

--- a/src/components/whole-app/nav-top-bar/nav-user-menu/nav-user-menu.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-user-menu/nav-user-menu.tsx
@@ -19,7 +19,14 @@ const NavUserMenu: React.FC = () => {
   return (
     <NavDropdown
       className="m-auto"
-      title={<FontAwesomeIcon icon={faUserCircle} size="2x" />}
+      title={
+        <div className={'d-flex flex-row'}>
+          <div className={'my-auto pr-2'}>
+            {auth.user?.firstName} {auth.user?.lastName}
+          </div>
+          <FontAwesomeIcon icon={faUserCircle} size="2x" />
+        </div>
+      }
       id="user-dropdown"
       alignRight
     >

--- a/src/components/whole-app/sidebar/sidebar-link/sidebar-link.module.css
+++ b/src/components/whole-app/sidebar/sidebar-link/sidebar-link.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/components/whole-app/sidebar/sidebar-link/sidebar-link.test.tsx
+++ b/src/components/whole-app/sidebar/sidebar-link/sidebar-link.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { faHome } from '@fortawesome/free-solid-svg-icons';
+import { render, screen, routerWrapperBuilder } from '../../../../test-support/test-utils';
+import SidebarLink from './sidebar-link';
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = (label: string) => {
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <SidebarLink link={'/'} icon={faHome} label={label} />
+    </RouterWrapper>
+  );
+};
+
+describe('sidebar link test', () => {
+  it('renders home page link', () => {
+    renderComponent('Home');
+    expect(screen.getByText(/Home/i)).toBeInTheDocument();
+  });
+
+  it('renders projects page link', () => {
+    renderComponent('Projects');
+    expect(screen.getByText(/Projects/i)).toBeInTheDocument();
+  });
+
+  it('renders change requests page link', () => {
+    renderComponent('Changes');
+    expect(screen.getByText(/Changes/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/whole-app/sidebar/sidebar-link/sidebar-link.tsx
+++ b/src/components/whole-app/sidebar/sidebar-link/sidebar-link.tsx
@@ -1,0 +1,26 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Link } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import './sidebar-link.module.css';
+
+interface SidebarLinkProps {
+  link: string;
+  label: string;
+  icon: IconProp;
+}
+
+const SidebarLink: React.FC<SidebarLinkProps> = ({ link, label, icon }) => {
+  return (
+    <Link className="nav-link d-flex flex-column" to={link}>
+      <FontAwesomeIcon className="mx-auto" icon={icon} size="lg" />
+      <p className="mx-auto mb-0">{label}</p>
+    </Link>
+  );
+};
+
+export default SidebarLink;

--- a/src/components/whole-app/sidebar/sidebar.module.css
+++ b/src/components/whole-app/sidebar/sidebar.module.css
@@ -1,0 +1,13 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+.mainBackground {
+  background-color: #ef4345;
+}
+
+.logo {
+  height: 35px;
+  transform: scale(1.5);
+}

--- a/src/components/whole-app/sidebar/sidebar.module.css
+++ b/src/components/whole-app/sidebar/sidebar.module.css
@@ -6,8 +6,3 @@
 .mainBackground {
   background-color: #ef4345;
 }
-
-.logo {
-  height: 35px;
-  transform: scale(1.5);
-}

--- a/src/components/whole-app/sidebar/sidebar.test.tsx
+++ b/src/components/whole-app/sidebar/sidebar.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
+import Sidebar from './sidebar';
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = () => {
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <Sidebar />
+    </RouterWrapper>
+  );
+};
+
+describe('navigation sidebar tests', () => {
+  it('renders navigation links', () => {
+    renderComponent();
+    expect(screen.getByText(/Home/i)).toBeInTheDocument();
+    expect(screen.getByText(/Projects/i)).toBeInTheDocument();
+    expect(screen.getByText(/Changes/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/whole-app/sidebar/sidebar.tsx
+++ b/src/components/whole-app/sidebar/sidebar.tsx
@@ -11,10 +11,10 @@ import styles from './sidebar.module.css';
 
 const Sidebar: React.FC = () => {
   return (
-    <Navbar className={styles.mainBackground} variant="light" expand="md" fixed="top">
+    <Navbar className={styles.mainBackground} variant="light" expand="md">
       <Navbar.Toggle aria-controls="sidebar-items" />
       <Navbar.Collapse id="sidebar-items">
-        <Nav className="ml-auto">
+        <Nav className="ml-auto flex-column">
           <SidebarLink link={routes.HOME} icon={faHome} label={'Home'} />
           <SidebarLink link={routes.PROJECTS} icon={faFolder} label={'Projects'} />
           <SidebarLink link={routes.CHANGE_REQUESTS} icon={faExchangeAlt} label={'Changes'} />

--- a/src/components/whole-app/sidebar/sidebar.tsx
+++ b/src/components/whole-app/sidebar/sidebar.tsx
@@ -1,0 +1,27 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { faFolder, faHome, faExchangeAlt } from '@fortawesome/free-solid-svg-icons';
+import { Navbar, Nav } from 'react-bootstrap';
+import { routes } from '../../../shared/routes';
+import SidebarLink from './sidebar-link/sidebar-link';
+import styles from './sidebar.module.css';
+
+const Sidebar: React.FC = () => {
+  return (
+    <Navbar className={styles.mainBackground} variant="light" expand="md" fixed="top">
+      <Navbar.Toggle aria-controls="sidebar-items" />
+      <Navbar.Collapse id="sidebar-items">
+        <Nav className="ml-auto">
+          <SidebarLink link={routes.HOME} icon={faHome} label={'Home'} />
+          <SidebarLink link={routes.PROJECTS} icon={faFolder} label={'Projects'} />
+          <SidebarLink link={routes.CHANGE_REQUESTS} icon={faExchangeAlt} label={'Changes'} />
+        </Nav>
+      </Navbar.Collapse>
+    </Navbar>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
Okay, so, it turns out, I'm a bad developer. We had a dev quite a while ago take a stab at implementing a sidebar and he went with integrating a sidebar npm package, but never implemented any changes after opening the PR so I closed it as stale. This was me taking stab number 2 at this sidebar and utilizing just things from my memory. 

This really should have some more thoughtful time put into it by someone that likes front-end stuff. We should use this as a chance to think about the application (app-authenticated and down) structure as a whole. We want to structure it such that we can have both a fixed top bar and a fixed left side bar. This means figuring out how to flexibly shrink the page content by just enough to not go underneath the side and top bars.

You can also see below how I've attempted to add the name of the user to the top right so that things don't look so out of place with just the fake notification bell and the user icon.

<img width="1468" alt="Screen Shot 2021-12-16 at 12 12 37 AM" src="https://user-images.githubusercontent.com/51571627/146333057-b0b00866-06fe-44e7-92b1-5b8f9527b48f.png">

