### PR TITLE
Standardize stage gate CR field name to confirmDone

### DIFF
--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.test.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.test.tsx
@@ -159,7 +159,7 @@ describe('Change request details stage gate cr display element tests', () => {
     const cr: StageGateChangeRequest = exampleStageGateChangeRequest;
     renderComponent(cr);
     expect(screen.getByText(`Confirm WP Completed`)).toBeInTheDocument();
-    expect(screen.getByText(`${cr.confirmCompleted ? 'YES' : 'NO'}`)).toBeInTheDocument();
+    expect(screen.getByText(`${cr.confirmDone ? 'YES' : 'NO'}`)).toBeInTheDocument();
   });
 
   it('Renders leftover budget', () => {

--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
@@ -105,7 +105,7 @@ const buildStageGateChangeRequestDetails = (cr: StageGateChangeRequest): ReactEl
       body={
         <dl className="row">
           <dt className="col-4">Confirm WP Completed</dt>
-          <dd className="col">{booleanPipe(cr.confirmCompleted)}</dd>
+          <dd className="col">{booleanPipe(cr.confirmDone)}</dd>
           <div className="w-100"></div>
           <dt className="col-4">Leftover Budget</dt>
           <dd className="col">{dollarsPipe(cr.leftoverBudget)}</dd>
@@ -134,8 +134,16 @@ const ChangeRequestDetails: React.FC<ChangeRequestDetailsProps> = ({
 }: ChangeRequestDetailsProps) => {
   const reviewBtns = (
     <div className={styles.btnsContainer}>
-      <ActionButton link={`/change-requests/${changeRequest.crId}/accept`} icon={faThumbsUp} text='Accept' />
-      <ActionButton link={`/change-requests/${changeRequest.crId}/deny`} icon={faThumbsDown} text='Deny' />
+      <ActionButton
+        link={`/change-requests/${changeRequest.crId}/accept`}
+        icon={faThumbsUp}
+        text="Accept"
+      />
+      <ActionButton
+        link={`/change-requests/${changeRequest.crId}/deny`}
+        icon={faThumbsDown}
+        text="Deny"
+      />
     </div>
   );
 

--- a/src/services/tests/change-requests.api.test.ts
+++ b/src/services/tests/change-requests.api.test.ts
@@ -47,7 +47,7 @@ describe('change request api methods', () => {
 
     const result = await getSingleChangeRequest(50);
     expect(result.data).not.toHaveProperty('length');
-    expect(result.data).toHaveProperty('confirmCompleted');
+    expect(result.data).toHaveProperty('confirmDone');
     expect(result.data).toHaveProperty('leftoverBudget');
     expect(result.data.dateSubmitted).toHaveProperty('toUTCString');
   });

--- a/src/test-support/test-data/change-requests.stub.ts
+++ b/src/test-support/test-data/change-requests.stub.ts
@@ -75,7 +75,7 @@ export const exampleStageGateChangeRequest: StageGateChangeRequest = {
   dateSubmitted: new Date('02/25/21'),
   type: ChangeRequestType.StageGate,
   leftoverBudget: 26,
-  confirmCompleted: true
+  confirmDone: true
 };
 
 export const exampleAllChangeRequests: ChangeRequest[] = [

--- a/src/utils/src/types/change-request-types.ts
+++ b/src/utils/src/types/change-request-types.ts
@@ -44,7 +44,7 @@ export interface ActivationChangeRequest extends ChangeRequest {
 
 export interface StageGateChangeRequest extends ChangeRequest {
   leftoverBudget: number;
-  confirmCompleted: boolean;
+  confirmDone: boolean;
 }
 
 export interface ChangeRequestExplanation {


### PR DESCRIPTION
Simple fix to the bug where it was looking for the incorrect field name. Closes #416 

front-end showing the field is now correctly displayed as true aka "YES"
<img width="1394" alt="Screen Shot 2022-01-10 at 6 00 10 PM" src="https://user-images.githubusercontent.com/51571627/148852241-b11cc214-d50b-4779-a508-becd312805d2.png">

Back-end showing the `confirmDone` field set to `true` for this CR
<img width="1130" alt="Screen Shot 2022-01-10 at 5 59 29 PM" src="https://user-images.githubusercontent.com/51571627/148852190-982d855a-9152-48c4-8f3f-a341991e88c9.png">

