### PR TITLE
Sort CR table desc

### DIFF
--- a/src/components/change-requests/change-requests-table/change-requests-table/change-requests-table.tsx
+++ b/src/components/change-requests/change-requests-table/change-requests-table/change-requests-table.tsx
@@ -51,7 +51,7 @@ const ChangeRequestsTable: React.FC<ChangeRequestsTableProps> = ({
   const defaultSort: [{ dataField: any; order: SortOrder }] = [
     {
       dataField: 'id',
-      order: 'asc'
+      order: 'desc'
     }
   ];
 
@@ -81,7 +81,8 @@ const ChangeRequestsTable: React.FC<ChangeRequestsTableProps> = ({
         defaultSorted={defaultSort}
         rowEvents={rowEvents}
         noDataIndication="No Change Requests to Display"
-        rowStyle={{ cursor: 'pointer' }} />
+        rowStyle={{ cursor: 'pointer' }}
+      />
     </>
   );
 };


### PR DESCRIPTION
Sort the CR table descending so newest submitted CRs are displayed first. Closes #415.
<img width="1380" alt="Screen Shot 2022-01-10 at 6 07 58 PM" src="https://user-images.githubusercontent.com/51571627/148852946-51baba68-d427-49ca-b2d4-b3a70b34743e.png">

