### PR TITLE
#431 - Add condition for when buttons appear

### DIFF
--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
@@ -149,7 +149,7 @@ const ChangeRequestDetails: React.FC<ChangeRequestDetailsProps> = ({
 
   return (
     <>
-      <PageTitle title={`Change Request #${changeRequest.crId}`} actionButton={reviewBtns} />
+      <PageTitle title={`Change Request #${changeRequest.crId}`} actionButton={changeRequest.accepted !== undefined ? <></> : reviewBtns} />
 
       <PageBlock
         title={'Change Request Details'}


### PR DESCRIPTION
Added the condition that the approve and deny buttons show up only if the `accepted` column of a change request is not specified. This means that both approved and denied change requests won't have the buttons, but pending change requests will. Currently, the change request table doesn't indicate that a change request is denied, so it could be difficult to tell which change requests have already been reviewed.

Screenshot for approved CR:
![accepted-cr](https://user-images.githubusercontent.com/48561685/148886043-df065e3f-22c1-436a-9cc0-7684d4d02ef8.png)

Screenshot for denied CR:
![denied-cr](https://user-images.githubusercontent.com/48561685/148886058-6a144eb7-0ae7-4e5f-883c-1559a0d4b507.png)

Screenshot for pending CR:
![not-a-nor-d](https://user-images.githubusercontent.com/48561685/148886095-88263c8d-4efd-4a8c-8925-59c4ee51ff0d.png)

