### PR TITLE
#428 - Add review notes to details page

### DIFF
--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.test.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.test.tsx
@@ -134,3 +134,13 @@ describe('Change request details stage gate cr display element tests', () => {
     expect(screen.getByText(`Leftover Budget`)).toBeInTheDocument();
   });
 });
+
+describe('Change request review notes display elements test', () => {
+  const { reviewNotes } = exampleStandardChangeRequest;
+
+  it('Render review notes section complete', () => {
+    renderComponent(exampleStandardChangeRequest);
+    expect(screen.getByText('Review Notes')).toBeInTheDocument();
+    expect(screen.getByText(reviewNotes ? reviewNotes! : 'There are no review notes for this change request.')).toBeInTheDocument();
+  });
+});

--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
@@ -22,6 +22,7 @@ import ActivationDetails from './type-specific-details/activation-details/activa
 import StageGateDetails from './type-specific-details/stage-gate-details/stage-gate-details';
 import ImplementedChangesList from './implemented-changes-list/implemented-changes-list';
 import './change-request-details.module.css';
+import ReviewNotes from './review-notes/review-notes';
 
 const convertStatus = (cr: ChangeRequest): string => {
   if (cr.dateImplemented) {
@@ -88,6 +89,7 @@ const ChangeRequestDetails: React.FC<ChangeRequestDetailsProps> = ({
         }
       />
       {buildDetails(changeRequest)}
+      <ReviewNotes reviewNotes={changeRequest.reviewNotes} />
       <ImplementedChangesList
         changes={
           changeRequest.implementedChanges === undefined ? [] : changeRequest.implementedChanges

--- a/src/components/change-requests/change-request-details/change-request-details/review-notes/review-notes.module.css
+++ b/src/components/change-requests/change-request-details/change-request-details/review-notes/review-notes.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/components/change-requests/change-request-details/change-request-details/review-notes/review-notes.test.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/review-notes/review-notes.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { ChangeRequest } from "utils";
+import { exampleAllChangeRequests } from "../../../../../test-support/test-data/change-requests.stub";
+import { render, screen } from "../../../../../test-support/test-utils";
+import ReviewNotes from "./review-notes";
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = (cr: ChangeRequest) => {
+  return render(<ReviewNotes reviewNotes={cr.reviewNotes} />);
+};
+
+describe('Change request review notes test', () => {
+  // [0] = standard, [1] = activation, [2] = stage gate
+  const cr: ChangeRequest[] = exampleAllChangeRequests;
+
+  it('standard change request render review notes', () => {
+    renderComponent(cr[0]);
+
+    expect(screen.getByText('Review Notes')).toBeInTheDocument();
+    expect(screen.getByText(cr[0].reviewNotes ? cr[0].reviewNotes! : 'There are no review notes for this change request.')).toBeInTheDocument();
+  })
+
+  it('activation change request render review notes', () => {
+    renderComponent(cr[1]);
+
+    expect(screen.getByText('Review Notes')).toBeInTheDocument();
+    expect(screen.getByText(cr[1].reviewNotes ? cr[1].reviewNotes! : 'There are no review notes for this change request.')).toBeInTheDocument();
+  })
+
+  it('stage gate change request render review notes', () => {
+    renderComponent(cr[2]);
+
+    expect(screen.getByText('Review Notes')).toBeInTheDocument();
+    expect(screen.getByText(cr[2].reviewNotes ? cr[2].reviewNotes! : 'There are no review notes for this change request.')).toBeInTheDocument();
+  })
+});

--- a/src/components/change-requests/change-request-details/change-request-details/review-notes/review-notes.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/review-notes/review-notes.tsx
@@ -1,0 +1,26 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import PageBlock from "../../../../shared/page-block/page-block";
+
+interface ReviewNotesProps {
+  reviewNotes?: string
+}
+
+const ReviewNotes: React.FC<ReviewNotesProps> = ({
+  reviewNotes
+}: ReviewNotesProps) => {
+  return (
+    <PageBlock
+      title={'Review Notes'}
+      headerRight={<></>}
+      body={
+        <p>{reviewNotes ? reviewNotes : 'There are no review notes for this change request.'}</p>
+      }
+    />
+  );
+};
+
+export default ReviewNotes;


### PR DESCRIPTION
I added the review notes to be above the "Implemented Changes" list on the CR details page. Currently, it displays the review notes if they exist, and if there are no review notes, it fills the block in with a placeholder text. An alternative to this would be to conditionally show the review notes only if review notes exist for the change request. This could reduce the clutter of blocks on the page for change requests that haven't been reviewed yet. Let me know your thoughts about the alternative.

Has review notes:
![has-rn](https://user-images.githubusercontent.com/48561685/149219248-81c7487a-9ddd-4c4d-b951-39e15ad1f0c7.png)

Doesn't have review notes:
![no-rn](https://user-images.githubusercontent.com/48561685/149219256-a921b67c-1d6a-41b5-9994-ef149eeaadcf.png)
