### PR TITLE
#399 - Add deliverables & expected activities to wp summary

### DIFF
--- a/src/backend/functions/projects.ts
+++ b/src/backend/functions/projects.ts
@@ -28,7 +28,6 @@ import {
   WbsElementStatus,
   DescriptionBullet
 } from 'utils';
-import { changeRequestTransformer } from '../../services/transformers/change-requests.transformers';
 
 const prisma = new PrismaClient();
 

--- a/src/components/projects/wbs-details/project-container/project-container.tsx
+++ b/src/components/projects/wbs-details/project-container/project-container.tsx
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsNumber, WorkPackageSummary as WPSummary } from 'utils';
+import { WbsNumber, WorkPackage } from 'utils';
 import { wbsPipe } from '../../../../shared/pipes';
 import { useSingleProject } from '../../../../services/projects.hooks';
 import ProjectDetails from './project-details/project-details';
@@ -43,7 +43,7 @@ const ProjectContainer: React.FC<ProjectContainerProps> = ({ wbsNum }: ProjectCo
         headerRight={<></>}
         body={
           <>
-            {data!.workPackages.map((ele: WPSummary) => (
+            {data!.workPackages.map((ele: WorkPackage) => (
               <div key={wbsPipe(ele.wbsNum)} className="mt-3">
                 <WorkPackageSummary workPackage={ele} />
               </div>

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
@@ -36,6 +36,12 @@ describe('Rendering Work Package Summary Test', () => {
     expect(
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
+    wp.expectedActivities.slice(0, 3).map((expectedActivity) => {
+      expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
+    });
+    wp.deliverables.slice(0, 3).map((deliverable) => {
+      expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
+    });
   });
 
   it('renders all the fields, example 2', () => {
@@ -51,6 +57,12 @@ describe('Rendering Work Package Summary Test', () => {
     expect(
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
+    wp.expectedActivities.slice(0, 3).map((expectedActivity) => {
+      expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
+    });
+    wp.deliverables.slice(0, 3).map((deliverable) => {
+      expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
+    });
   });
 
   it('renders all the fields, example 3', () => {
@@ -66,5 +78,11 @@ describe('Rendering Work Package Summary Test', () => {
     expect(
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
+    wp.expectedActivities.slice(0, 3).map((expectedActivity) => {
+      expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
+    });
+    wp.deliverables.slice(0, 3).map((deliverable) => {
+      expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
@@ -36,10 +36,10 @@ describe('Rendering Work Package Summary Test', () => {
     expect(
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
-    wp.expectedActivities.slice(0, 3).map((expectedActivity) => {
+    wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
-    wp.deliverables.slice(0, 3).map((deliverable) => {
+    wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });
   });
@@ -57,10 +57,10 @@ describe('Rendering Work Package Summary Test', () => {
     expect(
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
-    wp.expectedActivities.slice(0, 3).map((expectedActivity) => {
+    wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
-    wp.deliverables.slice(0, 3).map((deliverable) => {
+    wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });
   });
@@ -78,10 +78,10 @@ describe('Rendering Work Package Summary Test', () => {
     expect(
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
-    wp.expectedActivities.slice(0, 3).map((expectedActivity) => {
+    wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
-    wp.deliverables.slice(0, 3).map((deliverable) => {
+    wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });
   });

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
@@ -6,18 +6,29 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Collapse } from 'react-bootstrap';
-import { WorkPackageSummary as WPSummary } from 'utils';
+import { WorkPackage } from 'utils';
 import { weeksPipe, wbsPipe, endDatePipe, listPipe } from '../../../../../shared/pipes';
 import { routes } from '../../../../../shared/routes';
 import styles from './work-package-summary.module.css';
 import { Col, Container, Row } from 'react-bootstrap';
 
 interface WorkPackageSummaryProps {
-  workPackage: WPSummary;
+  workPackage: WorkPackage;
 }
 
 const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) => {
   const [open, setOpen] = useState(false);
+  const expectedActivitiesList = (
+    <ul>
+      {workPackage.expectedActivities.slice(0, 3).map((item, idx) => <li key={idx}>{item.detail}</li>)}
+    </ul>
+  );
+  const deliverablesList = (
+    <ul>
+      {workPackage.deliverables.slice(0, 3).map((item, idx) => <li key={idx}>{item.detail}</li>)}
+    </ul>
+  );
+
   return (
     <Card>
       <Card.Header className={styles.header} onClick={() => setOpen(!open)} aria-expanded={open}>
@@ -41,6 +52,14 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
                 <Col xs={6} md={4}>
                   <b>Start date:</b> {workPackage.startDate.toLocaleDateString()} <br />
                   <b>End Date:</b> {endDatePipe(workPackage.startDate, workPackage.duration)}
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12} md={6}>
+                  <b>Expected Activities:</b> {expectedActivitiesList}
+                </Col>
+                <Col xs={12} md={6}>
+                  <b>Deliverables:</b> {deliverablesList}
                 </Col>
               </Row>
             </Container>

--- a/src/services/transformers/projects.transformers.ts
+++ b/src/services/transformers/projects.transformers.ts
@@ -4,7 +4,7 @@
  */
 
 import { DescriptionBullet, Project } from 'utils';
-import { workPackageSummaryTransformer } from './work-packages.transformers';
+import { workPackageTransformer } from './work-packages.transformers';
 
 /**
  * Transforms a description bullet to ensure deep field transformation of date objects.
@@ -30,7 +30,7 @@ export const projectTransformer = (project: Project) => {
   return {
     ...project,
     dateCreated: new Date(project.dateCreated),
-    workPackages: project.workPackages.map(workPackageSummaryTransformer),
+    workPackages: project.workPackages.map(workPackageTransformer),
     goals: project.goals.map(descriptionBulletTransformer),
     features: project.features.map(descriptionBulletTransformer),
     otherConstraints: project.otherConstraints.map(descriptionBulletTransformer)

--- a/src/services/transformers/work-packages.transformers.ts
+++ b/src/services/transformers/work-packages.transformers.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WorkPackage, WorkPackageSummary } from 'utils';
+import { WorkPackage } from 'utils';
 import { descriptionBulletTransformer } from './projects.transformers';
 
 /**
@@ -20,18 +20,4 @@ export const workPackageTransformer = (workPackage: WorkPackage) => {
     expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
     deliverables: workPackage.deliverables.map(descriptionBulletTransformer)
   };
-};
-
-/**
- * Transforms a work package summary to ensure deep field transformation of date objects.
- *
- * @param workPackageSummary Incoming work package summary object supplied by the HTTP response.
- * @returns Properly transformed work package summary object.
- */
-export const workPackageSummaryTransformer = (workPackageSummary: WorkPackageSummary) => {
-  return {
-    ...workPackageSummary,
-    startDate: new Date(workPackageSummary.startDate),
-    endDate: new Date(workPackageSummary.endDate)
-  } as WorkPackageSummary;
 };

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -45,16 +45,6 @@ export interface Project extends WbsElement {
   workPackages: WorkPackage[];
 }
 
-export interface WorkPackageSummary {
-  id: number;
-  wbsNum: WbsNumber;
-  name: string;
-  startDate: Date;
-  endDate: Date;
-  duration: number;
-  dependencies: WbsNumber[];
-}
-
 export interface WorkPackage extends WbsElement {
   orderInProject: number;
   progress: number;

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -42,7 +42,7 @@ export interface Project extends WbsElement {
   goals: DescriptionBullet[];
   features: DescriptionBullet[];
   otherConstraints: DescriptionBullet[];
-  workPackages: WorkPackageSummary[];
+  workPackages: WorkPackage[];
 }
 
 export interface WorkPackageSummary {


### PR DESCRIPTION
In order to add deliverables and expected activities to the work package summary, I had to revert the several type usages from `WorkPackageSummary` back to `WorkPackage`.  I also had to modify the `workPackage` field on the `Project` type to use `WorkPackage[]` instead of `WorkPackageSummary[]`, which meant I had to do some modifications to the project transformer. I'm not completely sure I did the includes correctly, but it seems to work right now. I'm open to suggestions on how to improve the changes I made to the project transformer.

Note: @jamescd18 and I discussed how many deliverables and expected activities to display in the summary, and we decided on 3 being the max, which you will see reflected in the screenshots.

Screenshots of the new work package summary:
Work packages with 3 or less deliverables/expected activities
![normal-and-less](https://user-images.githubusercontent.com/48561685/150262723-2795eb89-586b-41ef-b646-fbe0f8cd1124.png)

Work package with more than 3 expected activities
![limit-to-3](https://user-images.githubusercontent.com/48561685/150262758-84158b0c-7ce2-4a9b-97de-1a09d4e734c6.png)


