### PR TITLE
#418 page title overflow

### DIFF
--- a/src/components/change-requests/change-requests-table/change-requests-table.module.css
+++ b/src/components/change-requests/change-requests-table/change-requests-table.module.css
@@ -5,7 +5,6 @@
 
 .container {
   width: 100%;
-  padding: 0 15px 15px 15px;
 }
 
 .filterTable {
@@ -15,8 +14,6 @@
   position: relative;
   margin-right: 0;
   margin-left: 0;
-  padding-left: 15px;
-  padding-right: 5px;
 }
 
 .crTable {
@@ -25,5 +22,4 @@
   flex-direction: row;
   width: 80%;
   position: relative;
-  padding-right: 5px;
 }

--- a/src/components/change-requests/change-requests-table/change-requests-table.tsx
+++ b/src/components/change-requests/change-requests-table/change-requests-table.tsx
@@ -167,7 +167,7 @@ const ChangeRequestsTable: React.FC = () => {
     <>
       <PageTitle title={'Change Requests'} actionButton={actionBtn} />
       <div className={styles.container}>
-        <Row>
+        <Row className={'mx-5'}>
           <div className={styles.filterTable}>
             <ChangeRequestsFilter update={sendDataToParent} />
           </div>

--- a/src/components/projects/projects-table/projects-table.module.css
+++ b/src/components/projects/projects-table/projects-table.module.css
@@ -5,7 +5,7 @@
 
 .container {
   width: 100%;
-  padding: 0 15px 15px 15px;
+  /* padding: 0 15px 15px 15px; */
 }
 
 .filterTable {
@@ -15,8 +15,6 @@
   position: relative;
   margin-right: 0;
   margin-left: 0;
-  padding-left: 15px;
-  padding-right: 5px;
 }
 
 .projectsTable {
@@ -25,6 +23,5 @@
   flex-direction: row;
   width: 80%;
   position: relative;
-  padding-right: 5px;
 }
 

--- a/src/components/projects/projects-table/projects-table.module.css
+++ b/src/components/projects/projects-table/projects-table.module.css
@@ -5,7 +5,6 @@
 
 .container {
   width: 100%;
-  /* padding: 0 15px 15px 15px; */
 }
 
 .filterTable {

--- a/src/components/projects/projects-table/projects-table.tsx
+++ b/src/components/projects/projects-table/projects-table.tsx
@@ -140,7 +140,7 @@ const ProjectsTable: React.FC = () => {
     <>
       <PageTitle title={'Projects'} />
       <div className={styles.container}>
-        <Row>
+        <Row className={'mx-5'}>
           <div className={styles.filterTable}>
             <ProjectsTableFilter
               onClick={sendDataToParent}

--- a/src/components/shared/page-title/page-title.module.css
+++ b/src/components/shared/page-title/page-title.module.css
@@ -2,15 +2,3 @@
  * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
-
-/* .titleRow {
-  display: flex;
-} */
-
-/* .title {
-  float: left;
-}
-
-.actionButton {
-  float: right;
-} */

--- a/src/components/shared/page-title/page-title.module.css
+++ b/src/components/shared/page-title/page-title.module.css
@@ -3,14 +3,14 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-.titleRow {
-  overflow: auto;
-}
+/* .titleRow {
+  display: flex;
+} */
 
-.title {
+/* .title {
   float: left;
 }
 
 .actionButton {
   float: right;
-}
+} */

--- a/src/components/shared/page-title/page-title.tsx
+++ b/src/components/shared/page-title/page-title.tsx
@@ -13,7 +13,7 @@ interface PageTitleProps {
 // Common component for all page titles
 const PageTitle: React.FC<PageTitleProps> = ({ title, actionButton }) => {
   return (
-    <div className={'mx-5 pt-3 pb-1 d-flex justify-content-between'}>
+    <div className={'mx-5 mb-4 pt-3 pb-1 d-flex justify-content-between'}>
       <h3 className={styles.title}>{title}</h3>
       <div className={styles.actionButton}>{actionButton}</div>
     </div>

--- a/src/components/shared/page-title/page-title.tsx
+++ b/src/components/shared/page-title/page-title.tsx
@@ -13,7 +13,7 @@ interface PageTitleProps {
 // Common component for all page titles
 const PageTitle: React.FC<PageTitleProps> = ({ title, actionButton }) => {
   return (
-    <div className={'mx-5 pt-3 pb-1 ' + styles.titleRow}>
+    <div className={'mx-5 pt-3 pb-1 d-flex justify-content-between'}>
       <h3 className={styles.title}>{title}</h3>
       <div className={styles.actionButton}>{actionButton}</div>
     </div>


### PR DESCRIPTION
This is to fix the issue with horizontal scroll bars appearing in the `PageTitle` component when an `ActionButton` is added to it. This also fixes the issue with dropdown buttons being considered overflow and having a vertical scroll bar to look through those that was discovered in #354. As a result, we can open up another ticket to go back to our original plan of using dropdown buttons as opposed to having separate buttons for "Accept" and "Deny".

I made additional edits to the spacing on the Projects and CR home pages to get them to align correctly with the title, and also added an experimental bottom margin to see how that looked. I thought that the previous way of having the title and content really tight and close together didn't look the greatest so I wanted to try changing it up a bit and seeing how it looked; I'm open to any thoughts on this.

Screenshots:
![project-home](https://user-images.githubusercontent.com/48561685/151919830-3a863590-0a94-43c4-abda-84121d62db6f.png)
![cr-home](https://user-images.githubusercontent.com/48561685/151919834-b6c545f2-e925-426d-8ba7-2bc3a09f01fc.png)
![cr-detail](https://user-images.githubusercontent.com/48561685/151919837-593c7a0c-a8ca-49d8-a455-380280c661b8.png)
![with-dropdown](https://user-images.githubusercontent.com/48561685/151919840-eaa189b9-49ee-44f4-b24a-a6d8dd5d284a.png)

