### PR TITLE
#406 Logout button now mirrors the setting button

### DIFF
--- a/src/components/whole-app/nav-top-bar/nav-user-menu/nav-user-menu.tsx
+++ b/src/components/whole-app/nav-top-bar/nav-user-menu/nav-user-menu.tsx
@@ -31,23 +31,27 @@ const NavUserMenu: React.FC = () => {
         </Link>
       </NavDropdown.Item>
       <NavDropdown.Item as="div">
-        <GoogleLogout
-          clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID!}
-          //jsSrc={'accounts.google.com/gsi/client'}
-          onLogoutSuccess={() => {
-            auth!.signout();
-            history.push(routes.HOME);
-          }}
-          render={(renderProps) => (
-            <button
-              className={'nav-link p-0 m-0 ' + styles.logoutButton}
-              onClick={renderProps.onClick}
-              disabled={renderProps.disabled}
-            >
-              Logout
-            </button>
-          )}
-        ></GoogleLogout>
+        <Link className="nav-link p-0" role="button" to="/login">
+          <GoogleLogout
+            clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID!}
+            //jsSrc={'accounts.google.com/gsi/client'}
+            onLogoutSuccess={() => {
+              auth!.signout();
+              history.push(routes.LOGIN);
+            }}
+            render={(renderProps) => (
+              <button
+                className={'nav-link p-0 m-0 ' + styles.logoutButton}
+                onClick={renderProps.onClick}
+                disabled={renderProps.disabled}
+              >
+                <Link className="nav-link p-0" role="button" to="/login">
+                  Logout
+                </Link>
+              </button>
+            )}
+          ></GoogleLogout>
+        </Link>
       </NavDropdown.Item>
     </NavDropdown>
   );


### PR DESCRIPTION
Fixed the front-end functionality for the logout button. Issue was related to GoogleLogout causing weird spacing issues. Fixed by including a link item within the GoogleLogout render prop. 

Also, whilst fixing this, we found an issue that the chrome back and forward buttons would still allow you to evade the log out. Example: You login, you logout, you hit the chrome back button and you are on the same page as before logging out with full functionality as a user.

Seemed out of scope to fix that issue, but just wanted to point it out. 