### PR TITLE
#403 - changed overflow for header from auto to hidden

### DIFF
--- a/src/components/shared/page-block/page-block.module.css
+++ b/src/components/shared/page-block/page-block.module.css
@@ -5,7 +5,7 @@
 
 .header {
   width: 100%;
-  overflow: auto;
+  overflow: hidden;
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
## Changes

Removed the scroll arrows from all text boxes by changing the overflow characteristics of the header where it's located
Changed this overflow property from auto to hidden to prevent any scroll arrows from existing
From trying out different options for headerRight text, it doesn't seem to cut off any of the text in headerRight (even multiline strings in this location); it just expands the size of the existing card. 

## Notes

N/A

## Test Cases

N/A

## Screenshots (if applicable)

In Project
![image](https://user-images.githubusercontent.com/98901845/157382951-a695ab2c-5489-4701-af99-6098b3ed4d28.png)

In Work Package
![image](https://user-images.githubusercontent.com/98901845/157383057-2a616499-da0a-4616-b553-ee61d08fce6f.png)

In Change Request
![image](https://user-images.githubusercontent.com/98901845/157383419-8ac42df1-cb0a-411e-8a85-1963dc6eb0a6.png)


## To Do

Completed

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #403 
