### PR TITLE
#430 projects clear filters

### DIFF
--- a/src/components/projects/projects-table/projects-table-filter/projects-table-filter.module.css
+++ b/src/components/projects/projects-table/projects-table-filter/projects-table-filter.module.css
@@ -32,6 +32,16 @@
   border-color: #ef4345 !important;
 }
 
+.clearButton {
+  float: left;
+  background-color: #ef4345 !important;
+  border-color: #ef4345 !important;
+}
+
 .applyButton:focus {
-  box-shadow: 0 0 0 .2rem rgba(239, 67, 69, 0.5) !important;
+  box-shadow: 0 0 0 0.2rem rgba(239, 67, 69, 0.5) !important;
+}
+
+.clearButton:focus {
+  box-shadow: 0 0 0 0.2rem rgba(239, 67, 69, 0.5) !important;
 }

--- a/src/components/projects/projects-table/projects-table-filter/projects-table-filter.test.tsx
+++ b/src/components/projects/projects-table/projects-table-filter/projects-table-filter.test.tsx
@@ -225,4 +225,70 @@ describe('projects table filter component', () => {
     });
     expect(temp[2]).toBe(-1);
   });
+
+  it('should have the correct text in the Clear button', async () => {
+    renderComponent();
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Clear'));
+    }); // Clicking it should do nothing to its visibility, not change the page, etc.
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+  });
+
+  it('should set all the filter values back to default after pressing clear', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Apply'));
+    });
+    expect(temp[0]).toBe('');
+    expect(temp[1]).toBe(-1);
+    expect(temp[2]).toBe(-1);
+    expect(temp[3]).toBe(-1);
+    // manager
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('manager-toggle'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Joe Blow'));
+    });
+    // status
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('status-toggle'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText(WbsElementStatus.Active));
+    });
+    // lead
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('lead-toggle'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Amy Smith'));
+    });
+    // car number
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('car-num-toggle'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('1'));
+    });
+    // apply all these filters
+    await act(async () => {
+      fireEvent.click(screen.getByText('Apply'));
+    });
+    // all filter values should have been set
+    expect(temp[0]).toBe(WbsElementStatus.Active);
+    expect(temp[1]).toBe(4);
+    expect(temp[2]).toBe(3);
+    expect(temp[3]).toBe(1);
+    // now clear
+    await act(async () => {
+      fireEvent.click(screen.getByText('Clear'));
+    });
+    // all filter values should now be back to defaults
+    expect(temp[0]).toBe('');
+    expect(temp[1]).toBe(-1);
+    expect(temp[2]).toBe(-1);
+    expect(temp[3]).toBe(-1);
+  });
 });

--- a/src/components/projects/projects-table/projects-table-filter/projects-table-filter.tsx
+++ b/src/components/projects/projects-table/projects-table-filter/projects-table-filter.tsx
@@ -214,6 +214,20 @@ const ProjectsTableFilter: React.FC<FilterProps> = ({ onClick, leads, managers }
             >
               Apply
             </Button>
+            <Button
+              className={styles.clearButton}
+              onClick={() => {
+                onClick('', -1, -1, -1);
+                setCar_number(-1);
+                setProject_leadID(-1);
+                setProject_leadName('');
+                setStatus('');
+                setProject_managerID(-1);
+                setProject_managerName('');
+              }}
+            >
+              Clear
+            </Button>
           </Form>
         </Card.Body>
       </Card>

--- a/src/components/projects/projects-table/projects-table-filter/projects-table-filter.tsx
+++ b/src/components/projects/projects-table/projects-table-filter/projects-table-filter.tsx
@@ -90,6 +90,19 @@ const ProjectsTableFilter: React.FC<FilterProps> = ({ onClick, leads, managers }
   };
 
   /**
+   * This function resets all the filter fields to default and sends the default values to the project table as well.
+   */
+  const resetFiltersToDefault = () => {
+    onClick('', -1, -1, -1);
+    setCar_number(-1);
+    setProject_leadID(-1);
+    setProject_leadName('');
+    setStatus('');
+    setProject_managerID(-1);
+    setProject_managerName('');
+  };
+
+  /**
    * Programmatically generates dropdown menu items for state variables representing users.
    * @param users The list of menu item values.
    * @param idSetter The setter function for the id of the user.
@@ -214,18 +227,7 @@ const ProjectsTableFilter: React.FC<FilterProps> = ({ onClick, leads, managers }
             >
               Apply
             </Button>
-            <Button
-              className={styles.clearButton}
-              onClick={() => {
-                onClick('', -1, -1, -1);
-                setCar_number(-1);
-                setProject_leadID(-1);
-                setProject_leadName('');
-                setStatus('');
-                setProject_managerID(-1);
-                setProject_managerName('');
-              }}
-            >
+            <Button className={styles.clearButton} onClick={resetFiltersToDefault}>
               Clear
             </Button>
           </Form>


### PR DESCRIPTION
## Changes

Added the clear button to the project filters. It resets the filters and the dropdown menus. Also added tests for it.

## Test Cases

- tested that the clear button appears on the screen
- tested that the clear button changes filter values back to the defaults

## Screenshots (if applicable)

Before clicking clear:
![Screenshot (1)](https://user-images.githubusercontent.com/63663597/157538105-b01d8362-7363-4716-90ce-19d8b2c66219.png)

After clicking clear:
![Screenshot (2)](https://user-images.githubusercontent.com/63663597/157538127-bdfc8681-4015-47c2-a957-d46d2e56fd9b.png)

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #430 
