### PR TITLE
#479 - Implement Work Package Timeline Status

### DIFF
--- a/src/backend/functions/projects.ts
+++ b/src/backend/functions/projects.ts
@@ -27,7 +27,8 @@ import {
   Project,
   WbsElementStatus,
   DescriptionBullet,
-  calculatePercentExpectedProgress
+  calculatePercentExpectedProgress,
+  calculateTimelineStatus
 } from 'utils';
 
 const prisma = new PrismaClient();
@@ -130,6 +131,11 @@ const projectTransformer = (
     workPackages: project.workPackages.map((workPackage) => {
       const endDate = new Date(workPackage.startDate);
       endDate.setDate(workPackage.duration * 7);
+      const expectedProgress = calculatePercentExpectedProgress(
+        workPackage.startDate,
+        workPackage.duration,
+        wbsElement.status
+      );
 
       return {
         ...workPackage,
@@ -138,11 +144,8 @@ const projectTransformer = (
         wbsNum: wbsNumOf(workPackage.wbsElement),
         status: convertStatus(workPackage.wbsElement.status),
         endDate,
-        expectedProgress: calculatePercentExpectedProgress(
-          workPackage.startDate,
-          workPackage.duration,
-          wbsElement.status
-        ),
+        expectedProgress,
+        timelineStatus: calculateTimelineStatus(workPackage.progress, expectedProgress),
         dependencies: workPackage.dependencies.map(wbsNumOf),
         expectedActivities: workPackage.expectedActivities.map(descBulletConverter),
         deliverables: workPackage.deliverables.map(descBulletConverter),

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -20,7 +20,8 @@ import {
   isProject,
   WorkPackage,
   WbsElementStatus,
-  calculatePercentExpectedProgress
+  calculatePercentExpectedProgress,
+  calculateTimelineStatus
 } from 'utils';
 
 const prisma = new PrismaClient();
@@ -73,6 +74,12 @@ const workPackageTransformer = (
   const endDate = new Date(workPackage.startDate);
   endDate.setDate(workPackage.duration * 7);
 
+  const expectedProgress = calculatePercentExpectedProgress(
+    workPackage.startDate,
+    workPackage.duration,
+    wbsElement.status
+  );
+
   const wbsNum = wbsNumOf(wbsElement);
   return {
     ...workPackage,
@@ -98,11 +105,8 @@ const workPackageTransformer = (
     status: convertStatus(wbsElement.status),
     wbsNum,
     endDate,
-    expectedProgress: calculatePercentExpectedProgress(
-      workPackage.startDate,
-      workPackage.duration,
-      wbsElement.status
-    )
+    expectedProgress,
+    timelineStatus: calculateTimelineStatus(workPackage.progress, expectedProgress)
   };
 };
 

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.test.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.test.tsx
@@ -35,6 +35,7 @@ describe('Rendering Work Package Details Component', () => {
       screen.getByText(`${endDatePipe(wp.startDate, wp.duration)}`, { exact: false })
     ).toBeInTheDocument();
     expect(screen.getByText(`${wp.progress}%`, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
     expect(
       screen.getByText(`${percentPipe(wp.expectedProgress)}`, { exact: false })
     ).toBeInTheDocument();
@@ -62,6 +63,7 @@ describe('Rendering Work Package Details Component', () => {
     ).toBeInTheDocument();
     const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
     expect(progresses.length).toBe(2);
+    expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
   });
 
   it('renders all the fields, example 3', () => {
@@ -85,5 +87,6 @@ describe('Rendering Work Package Details Component', () => {
     ).toBeInTheDocument();
     const progresses = screen.getAllByText(`${percentPipe(wp.progress)}`); // progress and expectedProgress should be equal and return 2 results
     expect(progresses.length).toBe(2);
+    expect(screen.getByText(`${wp.timelineStatus}`, { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
+++ b/src/components/projects/wbs-details/work-package-container/work-package-details/work-package-details.tsx
@@ -70,6 +70,12 @@ const WorkPackageDetails: React.FC<WorkPackageDetailsProps> = ({ workPackage }) 
               type="number"
               readOnly={true}
             />
+            <EditableDetail
+              title="Timeline Status"
+              value={workPackage.timelineStatus}
+              type="text"
+              readOnly={true}
+            />
           </Col>
         </Row>
       </Form>

--- a/src/test-support/test-data/work-packages.stub.ts
+++ b/src/test-support/test-data/work-packages.stub.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsElementStatus, WorkPackage, WorkPackageTimelineStatus } from 'utils';
+import { WbsElementStatus, WorkPackage, TimelineStatus } from 'utils';
 import {
   exampleAdminUser,
   exampleAppAdminUser,
@@ -30,7 +30,7 @@ export const exampleWorkPackage1: WorkPackage = {
   orderInProject: 1,
   progress: 25,
   expectedProgress: 50,
-  timelineStatus: WorkPackageTimelineStatus.OnTrack,
+  timelineStatus: TimelineStatus.OnTrack,
   startDate: new Date('01/01/21'),
   endDate: new Date('01/22/21'),
   duration: 3,
@@ -82,7 +82,7 @@ export const exampleWorkPackage2: WorkPackage = {
   orderInProject: 2,
   progress: 0,
   expectedProgress: 0,
-  timelineStatus: WorkPackageTimelineStatus.OnTrack,
+  timelineStatus: TimelineStatus.OnTrack,
   startDate: new Date('01/22/21'),
   endDate: new Date('02/26/21'),
   duration: 5,
@@ -143,7 +143,7 @@ export const exampleWorkPackage3: WorkPackage = {
   orderInProject: 3,
   progress: 100,
   expectedProgress: 100,
-  timelineStatus: WorkPackageTimelineStatus.OnTrack,
+  timelineStatus: TimelineStatus.OnTrack,
   startDate: new Date('01/01/21'),
   endDate: new Date('01/15/21'),
   duration: 2,

--- a/src/test-support/test-data/work-packages.stub.ts
+++ b/src/test-support/test-data/work-packages.stub.ts
@@ -3,7 +3,7 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { WbsElementStatus, WorkPackage } from 'utils';
+import { WbsElementStatus, WorkPackage, WorkPackageTimelineStatus } from 'utils';
 import {
   exampleAdminUser,
   exampleAppAdminUser,
@@ -30,6 +30,7 @@ export const exampleWorkPackage1: WorkPackage = {
   orderInProject: 1,
   progress: 25,
   expectedProgress: 50,
+  timelineStatus: WorkPackageTimelineStatus.OnTrack,
   startDate: new Date('01/01/21'),
   endDate: new Date('01/22/21'),
   duration: 3,
@@ -81,6 +82,7 @@ export const exampleWorkPackage2: WorkPackage = {
   orderInProject: 2,
   progress: 0,
   expectedProgress: 0,
+  timelineStatus: WorkPackageTimelineStatus.OnTrack,
   startDate: new Date('01/22/21'),
   endDate: new Date('02/26/21'),
   duration: 5,
@@ -141,6 +143,7 @@ export const exampleWorkPackage3: WorkPackage = {
   orderInProject: 3,
   progress: 100,
   expectedProgress: 100,
+  timelineStatus: WorkPackageTimelineStatus.OnTrack,
   startDate: new Date('01/01/21'),
   endDate: new Date('01/15/21'),
   duration: 2,

--- a/src/utils/src/backend-supports/projects-get-all.ts
+++ b/src/utils/src/backend-supports/projects-get-all.ts
@@ -43,6 +43,13 @@ const calculatePercentExpectedProgress = (start: Date, weeks: number, status: St
   }
 };
 
+/**
+ * Calculates a status of how current progress compares to expected progress.
+ *
+ * @param progress The reported progress, as a percentage.
+ * @param expectedProgress The expected progress, as a percentage.
+ * @returns The status of the progress compared to expectation.
+ */
 const calculateTimelineStatus = (progress: number, expectedProgress: number): TimelineStatus => {
   const delta = progress - expectedProgress;
   if (delta > 25) {

--- a/src/utils/src/backend-supports/projects-get-all.ts
+++ b/src/utils/src/backend-supports/projects-get-all.ts
@@ -4,6 +4,7 @@
  */
 
 import { WbsElementStatus } from '../types/project-types';
+import { WorkPackageTimelineStatus } from '../types/work-package-types';
 
 const calculateEndDate = (start: Date, weeks: number) => {
   const end = new Date(start);
@@ -42,4 +43,25 @@ const calculatePercentExpectedProgress = (start: Date, weeks: number, status: St
   }
 };
 
-export { projectDurationBuilder, calculateEndDate, calculatePercentExpectedProgress };
+const calculateTimelineStatus = (
+  progress: number,
+  expectedProgress: number
+): WorkPackageTimelineStatus => {
+  const delta = progress - expectedProgress;
+  if (delta > 25) {
+    return WorkPackageTimelineStatus.Ahead;
+  } else if (delta >= 0) {
+    return WorkPackageTimelineStatus.OnTrack;
+  } else if (delta >= -25) {
+    return WorkPackageTimelineStatus.Behind;
+  } else {
+    return WorkPackageTimelineStatus.VeryBehind;
+  }
+};
+
+export {
+  projectDurationBuilder,
+  calculateEndDate,
+  calculatePercentExpectedProgress,
+  calculateTimelineStatus
+};

--- a/src/utils/src/backend-supports/projects-get-all.ts
+++ b/src/utils/src/backend-supports/projects-get-all.ts
@@ -4,7 +4,7 @@
  */
 
 import { WbsElementStatus } from '../types/project-types';
-import { WorkPackageTimelineStatus } from '../types/work-package-types';
+import { TimelineStatus } from '../types/work-package-types';
 
 const calculateEndDate = (start: Date, weeks: number) => {
   const end = new Date(start);
@@ -43,19 +43,16 @@ const calculatePercentExpectedProgress = (start: Date, weeks: number, status: St
   }
 };
 
-const calculateTimelineStatus = (
-  progress: number,
-  expectedProgress: number
-): WorkPackageTimelineStatus => {
+const calculateTimelineStatus = (progress: number, expectedProgress: number): TimelineStatus => {
   const delta = progress - expectedProgress;
   if (delta > 25) {
-    return WorkPackageTimelineStatus.Ahead;
+    return TimelineStatus.Ahead;
   } else if (delta >= 0) {
-    return WorkPackageTimelineStatus.OnTrack;
+    return TimelineStatus.OnTrack;
   } else if (delta >= -25) {
-    return WorkPackageTimelineStatus.Behind;
+    return TimelineStatus.Behind;
   } else {
-    return WorkPackageTimelineStatus.VeryBehind;
+    return TimelineStatus.VeryBehind;
   }
 };
 

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -5,6 +5,7 @@
 
 import { User } from './user-types';
 import { ImplementedChange } from './change-request-types';
+import { WorkPackageTimelineStatus } from './work-package-types';
 import { FromSchema } from 'json-schema-to-ts';
 import { bodySchema, intType, stringType } from './api-utils-types';
 
@@ -53,6 +54,7 @@ export interface WorkPackage extends WbsElement {
   endDate: Date;
   duration: number;
   expectedProgress: number;
+  timelineStatus: WorkPackageTimelineStatus;
   dependencies: WbsNumber[];
   expectedActivities: DescriptionBullet[];
   deliverables: DescriptionBullet[];

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -5,7 +5,7 @@
 
 import { User } from './user-types';
 import { ImplementedChange } from './change-request-types';
-import { WorkPackageTimelineStatus } from './work-package-types';
+import { TimelineStatus } from './work-package-types';
 import { FromSchema } from 'json-schema-to-ts';
 import { bodySchema, intType, stringType } from './api-utils-types';
 
@@ -54,7 +54,7 @@ export interface WorkPackage extends WbsElement {
   endDate: Date;
   duration: number;
   expectedProgress: number;
-  timelineStatus: WorkPackageTimelineStatus;
+  timelineStatus: TimelineStatus;
   dependencies: WbsNumber[];
   expectedActivities: DescriptionBullet[];
   deliverables: DescriptionBullet[];

--- a/src/utils/src/types/work-package-types.ts
+++ b/src/utils/src/types/work-package-types.ts
@@ -53,3 +53,10 @@ export const workPackageEditInputSchemaBody = bodySchema(
 );
 
 export type EditWorkPackagePayload = FromSchema<typeof workPackageEditInputSchemaBody>;
+
+export enum WorkPackageTimelineStatus {
+  Ahead = 'AHEAD',
+  OnTrack = 'ON_TRACK',
+  Behind = 'BEHIND',
+  VeryBehind = 'VERY_BEHIND'
+}

--- a/src/utils/src/types/work-package-types.ts
+++ b/src/utils/src/types/work-package-types.ts
@@ -54,7 +54,7 @@ export const workPackageEditInputSchemaBody = bodySchema(
 
 export type EditWorkPackagePayload = FromSchema<typeof workPackageEditInputSchemaBody>;
 
-export enum WorkPackageTimelineStatus {
+export enum TimelineStatus {
   Ahead = 'AHEAD',
   OnTrack = 'ON_TRACK',
   Behind = 'BEHIND',

--- a/src/utils/tests/all-projects-support.test.ts
+++ b/src/utils/tests/all-projects-support.test.ts
@@ -9,7 +9,7 @@ import {
   calculateTimelineStatus
 } from '../src/backend-supports/projects-get-all';
 import { WbsElementStatus } from '../src/types/project-types';
-import { WorkPackageTimelineStatus } from '../src/types/work-package-types';
+import { TimelineStatus } from '../src/types/work-package-types';
 
 describe('calculateEndDate', () => {
   it('works with 0 weeks', () => {
@@ -98,22 +98,22 @@ describe('calculatePercentExpectedProgress', () => {
 
 describe('calculateTimelineStatus', () => {
   it('works Ahead of schedule', () => {
-    expect(calculateTimelineStatus(75, 30)).toEqual(WorkPackageTimelineStatus.Ahead);
+    expect(calculateTimelineStatus(75, 30)).toEqual(TimelineStatus.Ahead);
   });
 
   it('works OnTrack', () => {
-    expect(calculateTimelineStatus(55, 30)).toEqual(WorkPackageTimelineStatus.OnTrack);
+    expect(calculateTimelineStatus(55, 30)).toEqual(TimelineStatus.OnTrack);
   });
 
   it('works when progress is the same as expected progress', () => {
-    expect(calculateTimelineStatus(50, 50)).toEqual(WorkPackageTimelineStatus.OnTrack);
+    expect(calculateTimelineStatus(50, 50)).toEqual(TimelineStatus.OnTrack);
   });
 
   it('works Behind schedule', () => {
-    expect(calculateTimelineStatus(25, 30)).toEqual(WorkPackageTimelineStatus.Behind);
+    expect(calculateTimelineStatus(25, 30)).toEqual(TimelineStatus.Behind);
   });
 
   it('works VeryBehind schedule', () => {
-    expect(calculateTimelineStatus(0, 100)).toEqual(WorkPackageTimelineStatus.VeryBehind);
+    expect(calculateTimelineStatus(0, 100)).toEqual(TimelineStatus.VeryBehind);
   });
 });

--- a/src/utils/tests/all-projects-support.test.ts
+++ b/src/utils/tests/all-projects-support.test.ts
@@ -5,9 +5,11 @@
 import {
   calculateEndDate,
   projectDurationBuilder,
-  calculatePercentExpectedProgress
+  calculatePercentExpectedProgress,
+  calculateTimelineStatus
 } from '../src/backend-supports/projects-get-all';
 import { WbsElementStatus } from '../src/types/project-types';
+import { WorkPackageTimelineStatus } from '../src/types/work-package-types';
 
 describe('calculateEndDate', () => {
   it('works with 0 weeks', () => {
@@ -91,5 +93,27 @@ describe('calculatePercentExpectedProgress', () => {
   it('works with overdue ACTIVE status', () => {
     const startDate = new Date('March 20, 2020');
     expect(calculatePercentExpectedProgress(startDate, 3, WbsElementStatus.Active)).toEqual(100);
+  });
+});
+
+describe('calculateTimelineStatus', () => {
+  it('works Ahead of schedule', () => {
+    expect(calculateTimelineStatus(75, 30)).toEqual(WorkPackageTimelineStatus.Ahead);
+  });
+
+  it('works OnTrack', () => {
+    expect(calculateTimelineStatus(55, 30)).toEqual(WorkPackageTimelineStatus.OnTrack);
+  });
+
+  it('works when progress is the same as expected progress', () => {
+    expect(calculateTimelineStatus(50, 50)).toEqual(WorkPackageTimelineStatus.OnTrack);
+  });
+
+  it('works Behind schedule', () => {
+    expect(calculateTimelineStatus(25, 30)).toEqual(WorkPackageTimelineStatus.Behind);
+  });
+
+  it('works VeryBehind schedule', () => {
+    expect(calculateTimelineStatus(0, 100)).toEqual(WorkPackageTimelineStatus.VeryBehind);
   });
 });


### PR DESCRIPTION
## Changes

- Add TimelineStatus enum for work packages
- Create function to calculate timeline status from given progress and expectedProgress
- Add timeline status to work package front-end

## Test Cases

Utils - calculateTimelineStatus:
- Ahead
- OnTrack
- OnTrack: progress = expectedProgress (edge case)
- Behind
- VeryBehind

Front End:
- Timeline Status in the document

## Screenshots

<img width="1386" alt="Screen Shot 2022-03-16 at 4 05 49 PM" src="https://user-images.githubusercontent.com/59806366/158681519-d56b6f66-2005-42e2-8a01-205c47c32587.png">

## Checklist

- [X] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (if applicable)
- [X] Remove any not-applicable sections
- [X] Assign the PR to yourself
- [X] PR is linked to the ticket
- [X] No `package-lock.json` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack

Closes #479 
