### PR TITLE
#484 - remove required reviewer

### DIFF
--- a/src/components/change-requests/new-change-request/new-change-request-page/new-change-request-page.test.tsx
+++ b/src/components/change-requests/new-change-request/new-change-request-page/new-change-request-page.test.tsx
@@ -9,7 +9,6 @@ import { exampleAllWorkPackages } from '../../../../test-support/test-data/work-
 import { exampleAllProjects } from '../../../../test-support/test-data/projects.stub';
 import NewChangeRequestPage from './new-change-request-page';
 
-const whoDesignInquiry = 'Who is Required for Design Review?';
 const projectLeadStr = 'Project Lead';
 const scopeImpactStr = 'Scope Impact';
 
@@ -36,14 +35,12 @@ const renderComponent = (formType: ChangeRequestType) => {
 describe('new change request page', () => {
   it('checks if page renders correctly with redefinition type', () => {
     renderComponent(ChangeRequestType.Redefinition);
-    expect(screen.queryByText(whoDesignInquiry)).not.toBeInTheDocument();
     expect(screen.queryByText(projectLeadStr)).not.toBeInTheDocument();
     expect(screen.getByText(scopeImpactStr)).toBeInTheDocument();
   });
 
   it('checks if page renders correctly with issue type', () => {
     renderComponent(ChangeRequestType.Issue);
-    expect(screen.queryByText(whoDesignInquiry)).not.toBeInTheDocument();
     expect(screen.queryByText(projectLeadStr)).not.toBeInTheDocument();
     expect(screen.getByText(scopeImpactStr)).toBeInTheDocument();
   });
@@ -52,13 +49,11 @@ describe('new change request page', () => {
     renderComponent(ChangeRequestType.StageGate);
     expect(screen.queryByText(scopeImpactStr)).not.toBeInTheDocument();
     expect(screen.queryByText(projectLeadStr)).not.toBeInTheDocument();
-    expect(screen.getByText(whoDesignInquiry)).toBeInTheDocument();
   });
 
   it('checks if page renders correctly with activation type', () => {
     renderComponent(ChangeRequestType.Activation);
     expect(screen.queryByText(scopeImpactStr)).not.toBeInTheDocument();
-    expect(screen.queryByText(whoDesignInquiry)).not.toBeInTheDocument();
     expect(screen.getByText(projectLeadStr)).toBeInTheDocument();
   });
 });

--- a/src/components/change-requests/new-change-request/new-change-request-page/stage-gate-form-fileds/stage-gate-form-fields.test.tsx
+++ b/src/components/change-requests/new-change-request/new-change-request-page/stage-gate-form-fileds/stage-gate-form-fields.test.tsx
@@ -6,7 +6,6 @@
 import { render, screen } from '../../../../../test-support/test-utils';
 import StageGateFormFields from './stage-gate-form-fields';
 
-const requiredInquiry = 'Who is Required for Design Review?';
 const leftoverBudgetStr = 'Leftover Budget';
 const doneInquiry = 'Is everything done?';
 
@@ -18,12 +17,6 @@ const renderComponent = (handleChange: jest.Mock<any, any>) => {
 };
 
 describe('new stage gate form fields', () => {
-  it('renders the design reviewer form field', () => {
-    renderComponent(jest.fn());
-
-    expect(screen.getByText(requiredInquiry)).toBeInTheDocument();
-  });
-
   it('renders the Leftover Budget form field', () => {
     renderComponent(jest.fn());
 

--- a/src/components/change-requests/new-change-request/new-change-request-page/stage-gate-form-fileds/stage-gate-form-fields.tsx
+++ b/src/components/change-requests/new-change-request/new-change-request-page/stage-gate-form-fileds/stage-gate-form-fields.tsx
@@ -15,11 +15,6 @@ const StageGateFormFields: React.FC<StageGateProp> = ({ handleChange }) => {
     <div className={styles.container}>
       <div className={'px-4'}>
         <Form.Group controlId="newCR-project-design-review">
-          {/* This is not part of the activation currently. TODO */}
-
-          <Form.Label className={styles.label}>Who is Required for Design Review?</Form.Label>
-          <Form.Control as="textarea" rows={3} name="" required />
-
           <Form.Label className={styles.label}>Leftover Budget</Form.Label>
           <InputGroup>
             <InputGroup.Prepend>

--- a/src/components/change-requests/new-change-request/new-change-request.test.tsx
+++ b/src/components/change-requests/new-change-request/new-change-request.test.tsx
@@ -19,7 +19,6 @@ const project404 = '404 could not find the requested project request';
 const workPkg404 = '404 could not find the requested work package request';
 const error500 = '500 internal server error';
 const newChangeRequestStr = 'New Change Request';
-const whoDesignInquiry = 'Who is Required for Design Review?';
 const projectLeadStr = 'Project Lead';
 const scopeImpactStr = 'Scope Impact';
 
@@ -145,7 +144,6 @@ describe('change request page', () => {
     mockWorkPkgHook(false, false, exampleAllWorkPackages);
     renderComponent();
 
-    expect(screen.queryByText(whoDesignInquiry)).not.toBeInTheDocument();
     expect(screen.queryByText(projectLeadStr)).not.toBeInTheDocument();
     expect(screen.getByText(scopeImpactStr)).toBeInTheDocument();
 
@@ -155,14 +153,12 @@ describe('change request page', () => {
 
     expect(screen.queryByText(scopeImpactStr)).not.toBeInTheDocument();
     expect(screen.queryByText(projectLeadStr)).not.toBeInTheDocument();
-    expect(screen.getByText(whoDesignInquiry)).toBeInTheDocument();
 
     fireEvent.change(screen.getByTestId('type'), {
       target: { value: ChangeRequestType.Activation }
     });
 
     expect(screen.queryByText(scopeImpactStr)).not.toBeInTheDocument();
-    expect(screen.queryByText(whoDesignInquiry)).not.toBeInTheDocument();
     expect(screen.getByText(projectLeadStr)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Changes

Removed the required reviewers text input for stage gate change requests.

## Notes

n/a

## Test Cases

Updated by removing tests.

## Screenshots (if applicable)

<img width="1593" alt="Screen Shot 2022-03-26 at 3 57 24 AM" src="https://user-images.githubusercontent.com/51571627/160230457-ac9ada55-eade-4964-b296-19c07623faf9.png">

## To Do

n/a

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #484 
