### PR TITLE
#464 - Add Additional Bullets Count Link to Work Package Summary Accordion

### DIFF
--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.module.css
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.module.css
@@ -31,6 +31,17 @@
   min-width: 200px;
 }
 
+.showMoreLink {
+  color: #ef4345;
+  text-decoration: none;
+  float: right;
+}
+
+.showMoreLink:hover {
+  color: blue;
+  text-decoration: none;
+}
+
 b {
   font-weight: bold;
 }

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
@@ -81,6 +81,9 @@ describe('Rendering Work Package Summary Test', () => {
     wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(`Show ${wp.expectedActivities.length - 3} more...`, { exact: false })
+    ).toBeInTheDocument();
     wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.test.tsx
@@ -39,9 +39,15 @@ describe('Rendering Work Package Summary Test', () => {
     wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
+    expect(
+      screen.queryByText(`Show ${wp.expectedActivities.length - 3} more...`, { exact: false })
+    ).not.toBeInTheDocument();
     wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });
+    expect(
+      screen.queryByText(`Show ${wp.deliverables.length - 3} more...`, { exact: false })
+    ).not.toBeInTheDocument();
   });
 
   it('renders all the fields, example 2', () => {
@@ -60,9 +66,15 @@ describe('Rendering Work Package Summary Test', () => {
     wp.expectedActivities.slice(0, 3).forEach((expectedActivity) => {
       expect(screen.getByText(`${expectedActivity.detail}`)).toBeInTheDocument();
     });
+    expect(
+      screen.queryByText(`Show ${wp.expectedActivities.length - 3} more...`, { exact: false })
+    ).not.toBeInTheDocument();
     wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });
+    expect(
+      screen.queryByText(`Show ${wp.deliverables.length - 3} more...`, { exact: false })
+    ).not.toBeInTheDocument();
   });
 
   it('renders all the fields, example 3', () => {
@@ -87,5 +99,8 @@ describe('Rendering Work Package Summary Test', () => {
     wp.deliverables.slice(0, 3).forEach((deliverable) => {
       expect(screen.getByText(`${deliverable.detail}`)).toBeInTheDocument();
     });
+    expect(
+      screen.queryByText(`Show ${wp.deliverables.length - 3} more...`, { exact: false })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
+++ b/src/components/projects/wbs-details/project-container/work-package-summary/work-package-summary.tsx
@@ -25,6 +25,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
       ))}
     </ul>
   );
+  const numMoreExpectedActivities = workPackage.expectedActivities.length - 3;
   const deliverablesList = (
     <ul>
       {workPackage.deliverables.slice(0, 3).map((item, idx) => (
@@ -32,6 +33,7 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
       ))}
     </ul>
   );
+  const numMoreDeliverables = workPackage.deliverables.length - 3;
 
   return (
     <Card>
@@ -61,9 +63,29 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
               <Row>
                 <Col xs={12} md={6}>
                   <b>Expected Activities:</b> {expectedActivitiesList}
+                  {numMoreExpectedActivities > 0 ? (
+                    <Link
+                      to={`${routes.PROJECTS}/${wbsPipe(workPackage.wbsNum)}`}
+                      className={styles.showMoreLink}
+                    >
+                      Show {numMoreExpectedActivities} more...
+                    </Link>
+                  ) : (
+                    <></>
+                  )}
                 </Col>
                 <Col xs={12} md={6}>
                   <b>Deliverables:</b> {deliverablesList}
+                  {numMoreDeliverables > 0 ? (
+                    <Link
+                      to={`${routes.PROJECTS}/${wbsPipe(workPackage.wbsNum)}`}
+                      className={styles.showMoreLink}
+                    >
+                      Show {numMoreDeliverables} more...
+                    </Link>
+                  ) : (
+                    <></>
+                  )}
                 </Col>
               </Row>
             </Container>


### PR DESCRIPTION
## Changes

Add link to "See N more..." at the bottom of Expected Activities and Deliverables lists on the work package preview on the project page. Link leads to the work package page.

## Notes

Link is right-aligned and colored NER red using CSS. When hovered it will turn blue.

## Test Cases

- No link when list length less than 3
- No link when list length is exactly 3
- Link appears when list length is greater than 3

In the given examples, only Expected Activities list is tested because all examples have only one Deliverable

## Screenshots (if applicable)

![Screen Shot 2022-04-06 at 12 26 51 AM](https://user-images.githubusercontent.com/59806366/161895625-fefe6935-e866-47ef-884e-d491bd07f820.png)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors
- [X] No newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [X] No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (if applicable)
- [X] Remove any not-applicable sections
- [X] Assign the PR to yourself
- [X] PR is linked to the ticket
- [X] No `package-lock.json` changes (unless dependencies have changed)
- [X] Request reviewers & ping on Slack

Closes #464 
