### PR TITLE
#646 - display wbs link on cr details

### DIFF
--- a/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
+++ b/src/components/change-requests/change-request-details/change-request-details/change-request-details.tsx
@@ -11,7 +11,7 @@ import {
   StageGateChangeRequest,
   StandardChangeRequest
 } from 'utils';
-import { datePipe, fullNamePipe } from '../../../../shared/pipes';
+import { datePipe, fullNamePipe, wbsPipe } from '../../../../shared/pipes';
 import PageTitle from '../../../shared/page-title/page-title';
 import PageBlock from '../../../shared/page-block/page-block';
 import StandardDetails from './type-specific-details/standard-details/standard-details';
@@ -92,13 +92,21 @@ const ChangeRequestDetails: React.FC<ChangeRequestDetailsProps> = ({
         headerRight={<b>{convertStatus(changeRequest)}</b>}
         body={
           <dl className="row">
-            <dt className="col-2">Submitted</dt>
-            <dd className="col-2">{fullNamePipe(changeRequest.submitter)}</dd>
-            <dd className="col-3">{datePipe(changeRequest.dateSubmitted)}</dd>
+            <dt className="col-2">Project / Work Package</dt>
+            <dd className="col-auto">
+              {
+                <Link to={`${routes.PROJECTS}/${wbsPipe(changeRequest.wbsNum)}`}>
+                  {wbsPipe(changeRequest.wbsNum)}
+                </Link>
+              }
+            </dd>
             <div className="w-100"></div>
             <dt className="col-2">Type</dt>
             <dd className="col-auto">{changeRequest.type}</dd>
             <div className="w-100"></div>
+            <dt className="col-2">Submitted</dt>
+            <dd className="col-2">{fullNamePipe(changeRequest.submitter)}</dd>
+            <dd className="col-3">{datePipe(changeRequest.dateSubmitted)}</dd>
           </dl>
         }
       />


### PR DESCRIPTION
## Changes

display work package / project wbs number link on cr page

## Screenshots (if applicable)

<img width="795" alt="Screen Shot 2022-05-20 at 6 03 26 PM" src="https://user-images.githubusercontent.com/51571627/169618297-ef285eef-3f14-44b9-8070-4f582c36e9c3.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #646 
