### PR TITLE
#648 user dropdowns

### DIFF
--- a/src/components/projects/wbs-details/project-page/project-edit-container/project-edit-container.tsx
+++ b/src/components/projects/wbs-details/project-page/project-edit-container/project-edit-container.tsx
@@ -226,7 +226,7 @@ const ProjectEditContainer: React.FC<ProjectEditContainerProps> = ({ proj, exitE
         />
         <ProjectEditDetails
           project={proj}
-          users={allUsers.data!}
+          users={allUsers.data!.filter((u) => u.role !== 'GUEST')}
           updateSlideDeck={updateSlideDeck}
           updateTaskList={updateTaskList}
           updateBom={updateBom}

--- a/src/components/projects/wbs-details/project-page/project-edit-container/project-edit-details/project-edit-details.tsx
+++ b/src/components/projects/wbs-details/project-page/project-edit-container/project-edit-details/project-edit-details.tsx
@@ -103,6 +103,7 @@ const ProjectEditDetails: React.FC<projectDetailsProps> = ({
       as="select"
       data-testid="status-select"
       onChange={(e) => updateStatus(e.target.value as WbsElementStatus)}
+      custom
     >
       <option key={0} value={project.status}>
         {project.status}
@@ -131,6 +132,7 @@ const ProjectEditDetails: React.FC<projectDetailsProps> = ({
           as="select"
           data-testid={title}
           onChange={(e) => updateUser(parseInt(e.target.value))}
+          custom
         >
           {defaultUser === undefined ? (
             <option key={-1} value={-1}>

--- a/src/components/projects/wbs-details/project-page/project-edit-container/project-edit-details/project-edit-details.tsx
+++ b/src/components/projects/wbs-details/project-page/project-edit-container/project-edit-details/project-edit-details.tsx
@@ -3,11 +3,10 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Project, User } from 'utils';
+import { Project, User, WbsElementStatus } from 'utils';
 import { Col, Container, Row, Form, InputGroup } from 'react-bootstrap';
 import PageBlock from '../../../../../shared/page-block/page-block';
 import { wbsPipe, endDatePipe, fullNamePipe, emDashPipe } from '../../../../../../shared/pipes';
-import { WbsElementStatus } from 'utils/lib/types/project-types';
 
 // new parts added at the bottom
 interface projectDetailsProps {

--- a/src/components/projects/wbs-details/work-package-page/activate-work-package-modal-container/activate-work-package-modal-container.tsx
+++ b/src/components/projects/wbs-details/work-package-page/activate-work-package-modal-container/activate-work-package-modal-container.tsx
@@ -67,7 +67,7 @@ const ActivateWorkPackageModalContainer: React.FC<ActivateWorkPackageModalContai
       modalShow={modalShow}
       onHide={handleClose}
       onSubmit={handleConfirm}
-      allUsers={users.data!}
+      allUsers={users.data!.filter((u) => u.role !== 'GUEST')}
     />
   );
 };

--- a/src/components/projects/wbs-details/work-package-page/activate-work-package-modal-container/activate-work-package-modal/activate-work-package-modal.tsx
+++ b/src/components/projects/wbs-details/work-package-page/activate-work-package-modal-container/activate-work-package-modal/activate-work-package-modal.tsx
@@ -60,7 +60,7 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
 
             <Form.Group controlId="activateWPForm-ProjectLead">
               <Form.Label>Project Lead</Form.Label>
-              <Form.Control {...register('projectLeadId')} as="select">
+              <Form.Control {...register('projectLeadId')} as="select" custom>
                 <option key={-1} value={-1}></option>
                 {allUsers.map((p) => (
                   <option key={p.userId} value={p.userId}>
@@ -72,7 +72,7 @@ const ActivateWorkPackageModal: React.FC<ActivateWorkPackageModalProps> = ({
 
             <Form.Group controlId="activateWPForm-ProjectManager">
               <Form.Label>Project Manager</Form.Label>
-              <Form.Control {...register('projectManagerId')} as="select">
+              <Form.Control {...register('projectManagerId')} as="select" custom>
                 <option key={-1} value={-1}></option>
                 {allUsers.map((p) => (
                   <option key={p.userId} value={p.userId}>

--- a/src/components/projects/wbs-details/work-package-page/work-package-edit-container/work-package-edit-container.tsx
+++ b/src/components/projects/wbs-details/work-package-page/work-package-edit-container/work-package-edit-container.tsx
@@ -188,7 +188,11 @@ const WorkPackageEditContainer: React.FC<WorkPackageEditContainerProps> = ({
           required
           onChange={(e) => setCrId(e.target.value.trim())}
         />
-        <WorkPackageEditDetails workPackage={workPackage} users={userData!} setters={setters} />
+        <WorkPackageEditDetails
+          workPackage={workPackage}
+          users={userData!.filter((u) => u.role !== 'GUEST')}
+          setters={setters}
+        />
         <DependenciesList dependencies={workPackage.dependencies} setter={setDeps} />
         <PageBlock
           title="Expected Activities"

--- a/src/components/projects/wbs-details/work-package-page/work-package-edit-container/work-package-edit-details/work-package-edit-details.tsx
+++ b/src/components/projects/wbs-details/work-package-page/work-package-edit-container/work-package-edit-details/work-package-edit-details.tsx
@@ -78,7 +78,11 @@ const WorkPackageEditDetails: React.FC<Props> = ({ workPackage, users, setters }
   };
 
   const statusSelect = (
-    <Form.Control as="select" onChange={(e) => setters.setStatus(transformStatus(e.target.value))}>
+    <Form.Control
+      as="select"
+      onChange={(e) => setters.setStatus(transformStatus(e.target.value))}
+      custom
+    >
       <option key={0} value={workPackage.status}>
         {workPackage.status}
       </option>
@@ -97,7 +101,7 @@ const WorkPackageEditDetails: React.FC<Props> = ({ workPackage, users, setters }
     return (
       <>
         <b>{title}</b>
-        <Form.Control as="select" onChange={(e) => onChange(e.target.value)}>
+        <Form.Control as="select" onChange={(e) => onChange(e.target.value)} custom>
           <option key={defaultVal} value={defaultVal}>
             {`${defaultVal}%`}
           </option>
@@ -128,6 +132,7 @@ const WorkPackageEditDetails: React.FC<Props> = ({ workPackage, users, setters }
           as="select"
           data-testid={title}
           onChange={(e) => updateUser(parseInt(e.target.value))}
+          custom
         >
           {defaultUser === undefined ? (
             <option key={-1} value={-1}>


### PR DESCRIPTION
## Changes

change dropdowns to not include guest users.

## Screenshots (if applicable)

see matching styling on selects and 6 users instead of 7
<img width="630" alt="Screen Shot 2022-05-20 at 6 26 26 PM" src="https://user-images.githubusercontent.com/51571627/169620232-1e5f5139-5c2a-4699-b644-fab955bfa1ca.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #648 
