### PR TITLE
#669 - Reorganize DOM elements and display WP status on accordion

### DIFF
--- a/src/frontend/pages/ProjectDetailPage/project-view-container/work-package-summary/work-package-summary.module.css
+++ b/src/frontend/pages/ProjectDetailPage/project-view-container/work-package-summary/work-package-summary.module.css
@@ -15,7 +15,6 @@
 
 .duration {
   float: right;
-  margin-bottom: 0;
 }
 
 .wbsNum {

--- a/src/frontend/pages/ProjectDetailPage/project-view-container/work-package-summary/work-package-summary.tsx
+++ b/src/frontend/pages/ProjectDetailPage/project-view-container/work-package-summary/work-package-summary.tsx
@@ -7,7 +7,14 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Collapse } from 'react-bootstrap';
 import { WorkPackage } from 'utils';
-import { weeksPipe, wbsPipe, endDatePipe, listPipe, datePipe } from '../../../../../shared/pipes';
+import {
+  weeksPipe,
+  wbsPipe,
+  endDatePipe,
+  listPipe,
+  datePipe,
+  wbsStatusPipe
+} from '../../../../../shared/pipes';
 import { routes } from '../../../../../shared/routes';
 import styles from './work-package-summary.module.css';
 import { Col, Container, Row } from 'react-bootstrap';
@@ -38,12 +45,15 @@ const WorkPackageSummary: React.FC<WorkPackageSummaryProps> = ({ workPackage }) 
   return (
     <Card>
       <Card.Header className={styles.header} onClick={() => setOpen(!open)} aria-expanded={open}>
-        <div>
-          <p className={styles.wbsNum}>{wbsPipe(workPackage.wbsNum)}</p>
-          <p className={styles.name}>
+        <div className={'d-flex justify-content-between'}>
+          <div className={'d-flex'}>
+            <div className={'mr-3'}>{wbsPipe(workPackage.wbsNum)}</div>
             <Link to={`${routes.PROJECTS}/${wbsPipe(workPackage.wbsNum)}`}>{workPackage.name}</Link>
-          </p>
-          <p className={styles.duration}>{weeksPipe(workPackage.duration)}</p>
+          </div>
+          <div className={'d-flex'}>
+            <div className={'mr-3'}>{wbsStatusPipe(workPackage.status)}</div>
+            <div>{weeksPipe(workPackage.duration)}</div>
+          </div>
         </div>
       </Card.Header>
 


### PR DESCRIPTION
## Changes

Restyled / reorganized DOM elements to accommodate responsive design to display the work package status on the closed accordion.

## Screenshots (if applicable)

![Screen Shot 2022-05-26 at 9 12 29 PM](https://user-images.githubusercontent.com/51571627/170608769-d664a976-edb4-46e8-95ee-a0f76299a814.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #669 
