### PR TITLE
#674 - specify weeks for work package edit form

### DIFF
--- a/src/frontend/pages/WorkPackageDetailPage/work-package-edit-container/work-package-edit-details/work-package-edit-details.tsx
+++ b/src/frontend/pages/WorkPackageDetailPage/work-package-edit-container/work-package-edit-details/work-package-edit-details.tsx
@@ -204,8 +204,13 @@ const WorkPackageEditDetails: React.FC<Props> = ({ workPackage, users, setters }
             workPackage.projectManager,
             setters.setProjectManager
           )}
-          {editDetailsInputBuilder('Duration:', 'number', workPackage.duration, (val) =>
-            setters.setDuration(parseInt(val.trim()))
+          {editDetailsInputBuilder(
+            'Duration:',
+            'number',
+            workPackage.duration,
+            (val) => setters.setDuration(parseInt(val.trim())),
+            '',
+            'weeks'
           )}
         </Col>
         <Col xs={6} md={4}>


### PR DESCRIPTION
## Changes

Just added suffix weeks to work package edit form duration input

## Screenshots (if applicable)

![Screen Shot 2022-05-27 at 3 11 58 PM](https://user-images.githubusercontent.com/51571627/170775608-2aa1c6f3-3e8a-4e2e-8083-e3b0d4599a52.png)

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [ ] No linting errors
- [ ] No newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (if applicable)
- [ ] Remove any not-applicable sections
- [ ] Assign the PR to yourself
- [ ] PR is linked to the ticket
- [ ] No `package-lock.json` changes (unless dependencies have changed)
- [ ] Request reviewers & ping on Slack

Closes #674 
