### PR TITLE
#667 cut be fields

### DIFF
--- a/src/backend/functions/work-packages-create.ts
+++ b/src/backend/functions/work-packages-create.ts
@@ -111,7 +111,7 @@ export const createWorkPackage: Handler<FromSchema<typeof inputSchema>> = async 
   });
 
   // add to the database
-  const created = await prisma.work_Package.create({
+  await prisma.work_Package.create({
     data: {
       wbsElement: {
         create: {
@@ -138,7 +138,7 @@ export const createWorkPackage: Handler<FromSchema<typeof inputSchema>> = async 
     }
   });
 
-  return buildSuccessResponse(created);
+  return buildSuccessResponse({ message: 'Work Package Created' });
 };
 
 // expected structure of json body

--- a/src/backend/functions/work-packages-edit.ts
+++ b/src/backend/functions/work-packages-edit.ts
@@ -270,7 +270,7 @@ export const editWorkPackage: Handler<FromSchema<typeof inputSchema>> = async (
   await prisma.change.createMany({ data: changes });
 
   // return the updated work package
-  return buildSuccessResponse(updatedWorkPackage);
+  return buildSuccessResponse({ message: 'Work package updated successfully' });
 };
 
 /**

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -100,8 +100,12 @@ const workPackageTransformer = (
     expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
     deliverables: workPackage.deliverables.map(descriptionBulletTransformer),
     changes: wbsElement.changes.map((change) => ({
-      ...change,
-      wbsNum
+      wbsNum,
+      changeId: change.changeId,
+      changeRequestId: change.changeRequestId,
+      implementer: change.implementer,
+      detail: change.detail,
+      dateImplemented: change.dateImplemented
     })),
     dependencies: workPackage.dependencies.map(wbsNumOf),
     projectManager: wbsElement.projectManager ?? undefined,

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -4,7 +4,13 @@
  */
 
 import { Handler } from '@netlify/functions';
-import { Prisma, PrismaClient, WBS_Element, WBS_Element_Status } from '@prisma/client';
+import {
+  Description_Bullet,
+  Prisma,
+  PrismaClient,
+  WBS_Element,
+  WBS_Element_Status
+} from '@prisma/client';
 import {
   ApiRoute,
   ApiRouteFunction,
@@ -64,6 +70,13 @@ const wbsNumOf = (element: WBS_Element): WbsNumber => ({
   workPackageNumber: element.workPackageNumber
 });
 
+const descriptionBulletTransformer = (descBullet: Description_Bullet) => ({
+  id: descBullet.descriptionId,
+  detail: descBullet.detail,
+  dateAdded: descBullet.dateAdded,
+  dateDeleted: descBullet.dateDeleted ?? undefined
+});
+
 const workPackageTransformer = (
   payload:
     | Prisma.Work_PackageGetPayload<typeof manyRelationArgs>
@@ -72,7 +85,6 @@ const workPackageTransformer = (
   if (payload === null) throw new TypeError('WBS_Element not found');
   const wbsElement = 'wbsElement' in payload ? payload.wbsElement : payload;
   const workPackage = 'workPackage' in payload ? payload.workPackage! : payload;
-  const endDate = calculateEndDate(workPackage.startDate, workPackage.duration);
 
   const expectedProgress = calculatePercentExpectedProgress(
     workPackage.startDate,
@@ -85,16 +97,8 @@ const workPackageTransformer = (
     ...workPackage,
     ...wbsElement,
     id: workPackage.workPackageId,
-    expectedActivities: workPackage.expectedActivities.map((descBullet) => ({
-      ...descBullet,
-      id: descBullet.descriptionId,
-      dateDeleted: descBullet.dateDeleted ?? undefined
-    })),
-    deliverables: workPackage.deliverables.map((deliverable) => ({
-      ...deliverable,
-      id: deliverable.descriptionId,
-      dateDeleted: deliverable.dateDeleted ?? undefined
-    })),
+    expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
+    deliverables: workPackage.deliverables.map(descriptionBulletTransformer),
     changes: wbsElement.changes.map((change) => ({
       ...change,
       wbsNum
@@ -104,7 +108,7 @@ const workPackageTransformer = (
     projectLead: wbsElement.projectLead ?? undefined,
     status: convertStatus(wbsElement.status),
     wbsNum,
-    endDate,
+    endDate: calculateEndDate(workPackage.startDate, workPackage.duration),
     expectedProgress,
     timelineStatus: calculateTimelineStatus(workPackage.progress, expectedProgress)
   };

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -94,19 +94,15 @@ const workPackageTransformer = (
 
   const wbsNum = wbsNumOf(wbsElement);
   return {
-    ...workPackage,
-    ...wbsElement,
     id: workPackage.workPackageId,
+    dateCreated: wbsElement.dateCreated,
+    name: wbsElement.name,
+    orderInProject: workPackage.orderInProject,
+    progress: workPackage.progress,
+    startDate: workPackage.startDate,
+    duration: workPackage.duration,
     expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
     deliverables: workPackage.deliverables.map(descriptionBulletTransformer),
-    changes: wbsElement.changes.map((change) => ({
-      wbsNum,
-      changeId: change.changeId,
-      changeRequestId: change.changeRequestId,
-      implementer: change.implementer,
-      detail: change.detail,
-      dateImplemented: change.dateImplemented
-    })),
     dependencies: workPackage.dependencies.map(wbsNumOf),
     projectManager: wbsElement.projectManager ?? undefined,
     projectLead: wbsElement.projectLead ?? undefined,
@@ -114,7 +110,15 @@ const workPackageTransformer = (
     wbsNum,
     endDate: calculateEndDate(workPackage.startDate, workPackage.duration),
     expectedProgress,
-    timelineStatus: calculateTimelineStatus(workPackage.progress, expectedProgress)
+    timelineStatus: calculateTimelineStatus(workPackage.progress, expectedProgress),
+    changes: wbsElement.changes.map((change) => ({
+      wbsNum,
+      changeId: change.changeId,
+      changeRequestId: change.changeRequestId,
+      implementer: change.implementer,
+      detail: change.detail,
+      dateImplemented: change.dateImplemented
+    }))
   };
 };
 


### PR DESCRIPTION
## Changes

Cut down on extraneous fields being sent back by the back-end by explicitly defining all the fields we want sent and not using the spread operator.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #667 
