### PR TITLE
#689 - cut spread operator from users endpoint

### DIFF
--- a/src/backend/functions/users.ts
+++ b/src/backend/functions/users.ts
@@ -25,7 +25,6 @@ const usersTransformer = (user: Prisma.UserGetPayload<null>): User => {
   if (user === null) throw new TypeError('User not found');
 
   return {
-    ...user,
     userId: user.userId ?? undefined,
     firstName: user.firstName ?? undefined,
     lastName: user.lastName ?? undefined,


### PR DESCRIPTION
## Changes

Just cut out the spread operator to avoid leaking future user fields.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #689 
