### PR TITLE
#544 - Error Boundary

### DIFF
--- a/src/frontend/app/app-main/app-main.tsx
+++ b/src/frontend/app/app-main/app-main.tsx
@@ -9,7 +9,6 @@ import AppPublic from '../app-public/app-public';
 import './app-main.module.css';
 
 const AppMain: React.FC = () => {
-  throw Error('oopsie doopsie');
   return (
     <AppContext>
       <BrowserRouter>

--- a/src/frontend/app/app-main/app-main.tsx
+++ b/src/frontend/app/app-main/app-main.tsx
@@ -9,6 +9,7 @@ import AppPublic from '../app-public/app-public';
 import './app-main.module.css';
 
 const AppMain: React.FC = () => {
+  throw Error('oopsie doopsie');
   return (
     <AppContext>
       <BrowserRouter>

--- a/src/frontend/components/error-boundary/error-boundary.tsx
+++ b/src/frontend/components/error-boundary/error-boundary.tsx
@@ -26,9 +26,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
             'Please send a screenshot of this error to the software team, and try reloading the page to resolve the issue.'
           }
           error={this.state.error}
-        >
-          {' '}
-        </ErrorPage>
+        />
       );
     }
 

--- a/src/frontend/components/error-boundary/error-boundary.tsx
+++ b/src/frontend/components/error-boundary/error-boundary.tsx
@@ -1,0 +1,39 @@
+import { Component } from 'react';
+import ErrorPage from '../../pages/ErrorPage/error-page';
+
+interface ErrorBoundaryProps {}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: any;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorPage
+          message={
+            'Please send a screenshot of this error to the software team, and try reloading the page to resolve the issue.'
+          }
+          error={this.state.error}
+        >
+          {' '}
+        </ErrorPage>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/frontend/pages/ErrorPage/error-page.tsx
+++ b/src/frontend/pages/ErrorPage/error-page.tsx
@@ -3,19 +3,29 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
+import { Container } from 'react-bootstrap';
+import PageBlock from '../../layouts/page-block/page-block';
 import styles from './error-page.module.css';
 
 interface ErrorPageProps {
   message?: string;
+  error?: Error;
 }
 
 // Common page to display an error
-const ErrorPage: React.FC<ErrorPageProps> = ({ message }) => {
+const ErrorPage: React.FC<ErrorPageProps> = ({ message, error }) => {
   return (
     <div className={styles.text}>
       <h3>Oops, sorry!</h3>
       <h5>There was an error loading the page.</h5>
       {message ? <p>{message}</p> : ''}
+      {error ? (
+        <PageBlock
+          title={'Debugging Info: '}
+          headerRight={<></>}
+          body={<Container>{JSON.stringify(error, Object.getOwnPropertyNames(error))}</Container>}
+        />
+      ) : null}
     </div>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,10 +10,13 @@ import reportWebVitals from './reportWebVitals';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'react-bootstrap-table-next/dist/react-bootstrap-table2.min.css';
 import './custom.scss';
+import ErrorBoundary from './frontend/components/error-boundary/error-boundary';
 
 ReactDOM.render(
   <React.StrictMode>
-    <AppMain />
+    <ErrorBoundary>
+      <AppMain />
+    </ErrorBoundary>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
## Changes

Implemented React Error Boundaries, so that when an unexpected error occurs in the application, a helpful error page is displayed to the user rather than a blank white page.

## Notes

It might be worth looking into implementing this at specific points throughout the app in the future as an unexpected error in any child component of app-main will cause this display to pop up right now, but for now I think this implementation should help the users/us with debugging as more bugs start cropping up. The only notes I have are that I would appreciate any/all feedback on the design, I know it doesn't matter that much, but it looks kinda meh rn.

## Test Cases

- Test that the error boundary causes an error page to  pop up when an error occurs in any of app-main's children.

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/29521172/171958407-8cf00962-ae98-4451-a597-ee297f2166e2.png)


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes # (issue #544 )
