### PR TITLE
#650 - add back-end check to prevent reviewing your own cr

### DIFF
--- a/src/backend/functions/change-requests-review.ts
+++ b/src/backend/functions/change-requests-review.ts
@@ -33,8 +33,11 @@ export const reviewChangeRequest: Handler<FromSchema<typeof inputSchema>> = asyn
   if (reviewer.role === Role.GUEST || reviewer.role === Role.MEMBER) return buildNoAuthResponse();
 
   // ensure existence of change request
-  const foundCR = prisma.change_Request.findUnique({ where: { crId } });
+  const foundCR = await prisma.change_Request.findUnique({ where: { crId } });
   if (!foundCR) return buildNotFoundResponse('change request', `#${crId}`);
+
+  // verify that the user is not reviewing their own change request
+  if (reviewerId === foundCR.submitterId) return buildNoAuthResponse();
 
   // update change request
   const update = await prisma.change_Request.update({


### PR DESCRIPTION
## Changes

Prevent reviewing your own CR in the back-end too

## Screenshots
Review own CR response:
<img width="597" alt="Screen Shot 2022-06-15 at 10 36 55 AM" src="https://user-images.githubusercontent.com/51571627/173854339-abec3614-14a7-4cef-88b5-4c899db28c58.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #650 
