### PR TITLE
#712 help page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1492,11 +1492,6 @@
         }
       }
     },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
-      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
-    },
     "@fortawesome/fontawesome-svg-core": {
       "version": "1.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,32 +1493,63 @@
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.35",
-      "resolved": false,
-      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.35",
-      "resolved": false,
-      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.36",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+          "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
+        }
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "5.15.3",
-      "resolved": false,
-      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.36",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+          "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
+        }
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.14",
-      "resolved": false,
-      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
       "requires": {
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -142,9 +142,10 @@
     ]
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.35",
-    "@fortawesome/free-solid-svg-icons": "^5.15.3",
-    "@fortawesome/react-fontawesome": "^0.1.14",
+    "@fortawesome/fontawesome-common-types": "^6.1.1",
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/react-fontawesome": "^0.1.18",
     "@hookform/resolvers": "^2.8.8",
     "@middy/core": "^2.5.4",
     "@middy/http-error-handler": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     ]
   },
   "dependencies": {
-    "@fortawesome/fontawesome-common-types": "^6.1.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.18",

--- a/src/frontend/app/app-authenticated/app-authenticated.tsx
+++ b/src/frontend/app/app-authenticated/app-authenticated.tsx
@@ -11,8 +11,9 @@ import { PageNotFound } from '../../pages/PageNotFoundPage/page-not-found';
 import Home from '../../pages/HomePage/home';
 import NavTopBar from '../../layouts/nav-top-bar/nav-top-bar';
 import Settings from '../../pages/SettingsPage/settings';
-import styles from './app-authenticated.module.css';
+import HelpPage from '../../pages/HelpPage/HelpPage';
 import Sidebar from '../../layouts/sidebar/sidebar';
+import styles from './app-authenticated.module.css';
 
 const AppAuthenticated: React.FC = () => {
   return (
@@ -25,6 +26,7 @@ const AppAuthenticated: React.FC = () => {
             <Route path={routes.PROJECTS} component={Projects} />
             <Route path={routes.CHANGE_REQUESTS} component={ChangeRequests} />
             <Route path={routes.SETTINGS} component={Settings} />
+            <Route path={routes.HELP} component={HelpPage} />
             <Route exact path={routes.HOME} component={Home} />
             <Route path="*" component={PageNotFound} />
           </Switch>

--- a/src/frontend/layouts/sidebar/sidebar.tsx
+++ b/src/frontend/layouts/sidebar/sidebar.tsx
@@ -7,7 +7,12 @@ import { Nav } from 'react-bootstrap';
 import styles from './sidebar.module.css';
 import NavPageLinks, { LinkItem } from './nav-page-links/nav-page-links';
 import { routes } from '../../../shared/routes';
-import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExchangeAlt,
+  faFolder,
+  faHome,
+  faQuestionCircle
+} from '@fortawesome/free-solid-svg-icons';
 
 const Sidebar: React.FC = () => {
   const linkItems: LinkItem[] = [
@@ -25,6 +30,11 @@ const Sidebar: React.FC = () => {
       name: 'Change Requests',
       icon: faExchangeAlt,
       route: routes.CHANGE_REQUESTS
+    },
+    {
+      name: 'Help',
+      icon: faQuestionCircle,
+      route: routes.HELP
     }
   ];
   return (

--- a/src/frontend/pages/HelpPage/HelpPage.module.css
+++ b/src/frontend/pages/HelpPage/HelpPage.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/frontend/pages/HelpPage/HelpPage.test.tsx
+++ b/src/frontend/pages/HelpPage/HelpPage.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
+import { routes } from '../../../shared/routes';
+import HelpPage from './HelpPage';
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = () => {
+  const RouterWrapper = routerWrapperBuilder({ path: routes.HELP, route: routes.HELP });
+  return render(
+    <RouterWrapper>
+      <HelpPage />
+    </RouterWrapper>
+  );
+};
+
+describe('help page component', () => {
+  it('renders title', () => {
+    renderComponent();
+    expect(screen.getByText('Help')).toBeInTheDocument();
+  });
+
+  it('renders resources section', () => {
+    renderComponent();
+    expect(screen.getByText(/Resources/)).toBeInTheDocument();
+    expect(screen.getByText(/Glossary/)).toBeInTheDocument();
+  });
+
+  it('renders support section', () => {
+    renderComponent();
+    expect(screen.getByText(/Support/)).toBeInTheDocument();
+    expect(screen.getByText(/Message in Slack/)).toBeInTheDocument();
+    expect(screen.getByText(/GitHub/)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/pages/HelpPage/HelpPage.tsx
+++ b/src/frontend/pages/HelpPage/HelpPage.tsx
@@ -4,8 +4,8 @@
  */
 
 import { Col, Container, Row } from 'react-bootstrap';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faScroll } from '@fortawesome/free-solid-svg-icons';
+import { iconLinkPipe } from '../../../shared/pipes';
 import PageTitle from '../../layouts/page-title/page-title';
 import PageBlock from '../../layouts/page-block/page-block';
 
@@ -19,8 +19,12 @@ const HelpPage: React.FC = () => {
         body={
           <Container fluid>
             <Row>
-              <Col md={6} lg={4}>
-                <FontAwesomeIcon icon={faScroll} size="1x" className="pr-1" />
+              <Col md={4} lg={2}>
+                {iconLinkPipe(
+                  faScroll,
+                  'Glossary Document',
+                  'https://docs.google.com/document/d/1_kr7PQxjYKvBTmZc8cxeSv5xx0lE88v0wVXkVg3Mez8/edit?usp=sharing'
+                )}
               </Col>
               <Col md={4} lg={2}></Col>
             </Row>

--- a/src/frontend/pages/HelpPage/HelpPage.tsx
+++ b/src/frontend/pages/HelpPage/HelpPage.tsx
@@ -1,0 +1,59 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Col, Container, Row } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faScroll } from '@fortawesome/free-solid-svg-icons';
+import PageTitle from '../../layouts/page-title/page-title';
+import PageBlock from '../../layouts/page-block/page-block';
+
+const HelpPage: React.FC = () => {
+  return (
+    <Container fluid>
+      <PageTitle title="Help" />
+      <PageBlock
+        title="Resources"
+        headerRight={<></>}
+        body={
+          <Container fluid>
+            <Row>
+              <Col md={6} lg={4}>
+                <FontAwesomeIcon icon={faScroll} size="1x" className="pr-1" />
+              </Col>
+              <Col md={4} lg={2}></Col>
+            </Row>
+          </Container>
+        }
+      />
+      <PageBlock
+        title="Support"
+        headerRight={<></>}
+        body={
+          <Container fluid>
+            <Row>
+              <Col md={4} lg={2}>
+                <b>First Name:</b>
+              </Col>
+              <Col md={4} lg={2}>
+                <b>Last Name:</b>
+              </Col>
+              <Col md={4} lg={3}>
+                <b>Email: </b>
+              </Col>
+              <Col md={4} lg={2}>
+                <b>Email ID:</b>
+              </Col>
+              <Col md={4} lg={2}>
+                <b>Role: </b>
+              </Col>
+            </Row>
+          </Container>
+        }
+      />
+    </Container>
+  );
+};
+
+export default HelpPage;

--- a/src/frontend/pages/HelpPage/HelpPage.tsx
+++ b/src/frontend/pages/HelpPage/HelpPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Col, Container, Row } from 'react-bootstrap';
-import { faScroll } from '@fortawesome/free-solid-svg-icons';
+import { faScroll, faCode, faCommentAlt } from '@fortawesome/free-solid-svg-icons';
 import { iconLinkPipe } from '../../../shared/pipes';
 import PageTitle from '../../layouts/page-title/page-title';
 import PageBlock from '../../layouts/page-block/page-block';
@@ -18,15 +18,16 @@ const HelpPage: React.FC = () => {
         headerRight={<></>}
         body={
           <Container fluid>
+            <Row className="pb-2">Check out these helpful resources:</Row>
             <Row>
-              <Col md={4} lg={2}>
+              <Col md={4} lg={3}>
                 {iconLinkPipe(
                   faScroll,
                   'Glossary Document',
                   'https://docs.google.com/document/d/1_kr7PQxjYKvBTmZc8cxeSv5xx0lE88v0wVXkVg3Mez8/edit?usp=sharing'
                 )}
               </Col>
-              <Col md={4} lg={2}></Col>
+              <Col>Got any suggestions for additional resources? Message in Slack!</Col>
             </Row>
           </Container>
         }
@@ -36,21 +37,24 @@ const HelpPage: React.FC = () => {
         headerRight={<></>}
         body={
           <Container fluid>
+            <Row className="pb-2">
+              Any and all questions, comments, suggestions, bugs, or other issues can be directed to
+              the resources below:
+            </Row>
             <Row>
-              <Col md={4} lg={2}>
-                <b>First Name:</b>
+              <Col sm={5} md={4} lg={3}>
+                {iconLinkPipe(
+                  faCommentAlt,
+                  'Message in Slack',
+                  'slack://channel?team=T7MHAQ5TL&id=C02U5TKHLER'
+                )}
               </Col>
-              <Col md={4} lg={2}>
-                <b>Last Name:</b>
-              </Col>
-              <Col md={4} lg={3}>
-                <b>Email: </b>
-              </Col>
-              <Col md={4} lg={2}>
-                <b>Email ID:</b>
-              </Col>
-              <Col md={4} lg={2}>
-                <b>Role: </b>
+              <Col sm={6} md={4} lg={3}>
+                {iconLinkPipe(
+                  faCode,
+                  'Submit a ticket on GitHub',
+                  'https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/issues/new/choose'
+                )}
               </Col>
             </Row>
           </Container>

--- a/src/frontend/pages/HelpPage/HelpPage.tsx
+++ b/src/frontend/pages/HelpPage/HelpPage.tsx
@@ -27,7 +27,7 @@ const HelpPage: React.FC = () => {
                   'https://docs.google.com/document/d/1_kr7PQxjYKvBTmZc8cxeSv5xx0lE88v0wVXkVg3Mez8/edit?usp=sharing'
                 )}
               </Col>
-              <Col>Got any suggestions for additional resources? Message in Slack!</Col>
+              <Col>Got any suggestions for additional resources? Drop a message in Slack!</Col>
             </Row>
           </Container>
         }

--- a/src/frontend/pages/HomePage/useful-links/useful-links.test.tsx
+++ b/src/frontend/pages/HomePage/useful-links/useful-links.test.tsx
@@ -26,6 +26,5 @@ describe('useful links component', () => {
     expect(screen.getByText(/Personal purchasing guidelines/i)).toBeInTheDocument();
     expect(screen.getByText(/Procurement form/i)).toBeInTheDocument();
     expect(screen.getByText(/Part numbering spreadsheet/i)).toBeInTheDocument();
-    expect(screen.getByText(/Glossary Document/i)).toBeInTheDocument();
   });
 });

--- a/src/frontend/pages/HomePage/useful-links/useful-links.tsx
+++ b/src/frontend/pages/HomePage/useful-links/useful-links.tsx
@@ -33,11 +33,7 @@ const UsefulLinks: React.FC = () => {
       'https://docs.google.com/spreadsheets/d/1kqpnw8jZDx2GO5NFUtqefRXqT1XX46iMx5ZI4euPJgY/edit'
     ),
     linkPipe('Individual Member Goals Form', 'https://forms.gle/MAZJSFcMBjn44p3F6'),
-    linkPipe('Manufacturing Request Form', 'https://forms.gle/vJmTRt2xnzGa7akb8'),
-    linkPipe(
-      'Glossary Document',
-      'https://docs.google.com/document/d/1_kr7PQxjYKvBTmZc8cxeSv5xx0lE88v0wVXkVg3Mez8/edit?usp=sharing'
-    )
+    linkPipe('Manufacturing Request Form', 'https://forms.gle/vJmTRt2xnzGa7akb8')
   ];
 
   return (

--- a/src/shared/pipes.tsx
+++ b/src/shared/pipes.tsx
@@ -7,6 +7,8 @@ import { ReactElement } from 'react';
 import { User } from '@prisma/client';
 import { WbsElementStatus, WbsNumber } from 'utils';
 import { Badge } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 /**
  * Pipes:
@@ -20,6 +22,15 @@ export const linkPipe = (description: string, link: string): ReactElement => {
     <a href={link} target="_blank" rel="noopener noreferrer">
       {description}
     </a>
+  );
+};
+
+export const iconLinkPipe = (icon: IconProp, description: string, link: string) => {
+  return (
+    <div className="d-flex flex-row align-items-center">
+      <FontAwesomeIcon icon={icon} size="1x" className="pr-1" />
+      {linkPipe(description, link)}
+    </div>
   );
 };
 

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -7,6 +7,7 @@
 const HOME = `/`;
 const LOGIN = `/login`;
 const SETTINGS = `/settings`;
+const HELP = `/help`;
 
 /**************** Projects Section ****************/
 const PROJECTS = `/projects`;
@@ -24,6 +25,7 @@ export const routes = {
   HOME,
   LOGIN,
   SETTINGS,
+  HELP,
 
   PROJECTS,
   PROJECTS_BY_WBS,


### PR DESCRIPTION
## Changes

Added a new help page. Added icon link pipe for fancy looking links for fun.

## Notes

I couldn't seem to get the types from `@fortawesome/free-brands-svg-icons` to work properly with the existing setup we have with fontawesome icons. Not even pulling in `@fortawesome/fontawesome-common-types` fixed the issue. So basically I gave up and chose different icons to represent Slack and GitHub. It kept saying the types are incompatible even when it really seemed like they were exactly the same types, but it's really tough given how it's some sorta enum of all possible options and I can't tell why it doesn't fit.

## Test Cases

updated tests, tested help page loosely.

## Screenshots (if applicable)

<img width="838" alt="Screen Shot 2022-06-15 at 4 58 54 PM" src="https://user-images.githubusercontent.com/51571627/173928354-d6b77dff-60e3-4b49-86b2-4bf8b24ed6ac.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #712 
