### PR TITLE
#729 timeline status home

### DIFF
--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -105,9 +105,20 @@ const workPackageTransformer = (wpInput: Prisma.Work_PackageGetPayload<typeof wp
 };
 
 // Fetch all work packages
-const getAllWorkPackages: ApiRouteFunction = async () => {
+const getAllWorkPackages: ApiRouteFunction = async (_, e) => {
   const workPackages = await prisma.work_Package.findMany(wpQueryArgs);
-  return buildSuccessResponse(workPackages.map(workPackageTransformer));
+  return buildSuccessResponse(
+    workPackages.map(workPackageTransformer).filter((wp) => {
+      let passes = true;
+      if (e.queryStringParameters?.status) {
+        passes = passes && wp.status === e.queryStringParameters?.status;
+      }
+      if (e.queryStringParameters?.timelineStatus) {
+        passes = passes && wp.timelineStatus === e.queryStringParameters?.timelineStatus;
+      }
+      return passes;
+    })
+  );
 };
 
 // Fetch the work package for the specified WBS number

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -105,17 +105,14 @@ const workPackageTransformer = (wpInput: Prisma.Work_PackageGetPayload<typeof wp
 };
 
 // Fetch all work packages
-const getAllWorkPackages: ApiRouteFunction = async (_, e) => {
+const getAllWorkPackages: ApiRouteFunction = async (_, event) => {
+  const { queryStringParameters: eQSP } = event;
   const workPackages = await prisma.work_Package.findMany(wpQueryArgs);
   return buildSuccessResponse(
     workPackages.map(workPackageTransformer).filter((wp) => {
       let passes = true;
-      if (e.queryStringParameters?.status) {
-        passes &&= wp.status === e.queryStringParameters?.status;
-      }
-      if (e.queryStringParameters?.timelineStatus) {
-        passes &&= wp.timelineStatus === e.queryStringParameters?.timelineStatus;
-      }
+      if (eQSP?.status) passes &&= wp.status === eQSP?.status;
+      if (eQSP?.timelineStatus) passes &&= wp.timelineStatus === eQSP?.timelineStatus;
       return passes;
     })
   );

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -155,7 +155,7 @@ const getAllWorkPackagesUpcomingDeadlines: ApiRouteFunction = async () => {
   const workPackages = await prisma.work_Package.findMany({
     where: {
       wbsElement: {
-        status: 'ACTIVE'
+        status: WBS_Element_Status.ACTIVE
       }
     },
     ...manyRelationArgs

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -111,10 +111,10 @@ const getAllWorkPackages: ApiRouteFunction = async (_, e) => {
     workPackages.map(workPackageTransformer).filter((wp) => {
       let passes = true;
       if (e.queryStringParameters?.status) {
-        passes = passes && wp.status === e.queryStringParameters?.status;
+        passes &&= wp.status === e.queryStringParameters?.status;
       }
       if (e.queryStringParameters?.timelineStatus) {
-        passes = passes && wp.timelineStatus === e.queryStringParameters?.timelineStatus;
+        passes &&= wp.timelineStatus === e.queryStringParameters?.timelineStatus;
       }
       return passes;
     })

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -33,7 +33,7 @@ import {
 
 const prisma = new PrismaClient();
 
-const manyRelationArgs = Prisma.validator<Prisma.Work_PackageArgs>()({
+const wpQueryArgs = Prisma.validator<Prisma.Work_PackageArgs>()({
   include: {
     wbsElement: {
       include: {
@@ -45,15 +45,6 @@ const manyRelationArgs = Prisma.validator<Prisma.Work_PackageArgs>()({
     expectedActivities: true,
     deliverables: true,
     dependencies: true
-  }
-});
-
-const uniqueRelationArgs = Prisma.validator<Prisma.WBS_ElementArgs>()({
-  include: {
-    workPackage: { include: { expectedActivities: true, deliverables: true, dependencies: true } },
-    projectLead: true,
-    projectManager: true,
-    changes: { include: { implementer: true } }
   }
 });
 
@@ -77,41 +68,32 @@ const descriptionBulletTransformer = (descBullet: Description_Bullet) => ({
   dateDeleted: descBullet.dateDeleted ?? undefined
 });
 
-const workPackageTransformer = (
-  payload:
-    | Prisma.Work_PackageGetPayload<typeof manyRelationArgs>
-    | Prisma.WBS_ElementGetPayload<typeof uniqueRelationArgs>
-): WorkPackage => {
-  if (payload === null) throw new TypeError('WBS_Element not found');
-  const wbsElement = 'wbsElement' in payload ? payload.wbsElement : payload;
-  const workPackage = 'workPackage' in payload ? payload.workPackage! : payload;
-
+const workPackageTransformer = (wpInput: Prisma.Work_PackageGetPayload<typeof wpQueryArgs>) => {
   const expectedProgress = calculatePercentExpectedProgress(
-    workPackage.startDate,
-    workPackage.duration,
-    wbsElement.status
+    wpInput.startDate,
+    wpInput.duration,
+    wpInput.wbsElement.status
   );
-
-  const wbsNum = wbsNumOf(wbsElement);
+  const wbsNum = wbsNumOf(wpInput.wbsElement);
   return {
-    id: workPackage.workPackageId,
-    dateCreated: wbsElement.dateCreated,
-    name: wbsElement.name,
-    orderInProject: workPackage.orderInProject,
-    progress: workPackage.progress,
-    startDate: workPackage.startDate,
-    duration: workPackage.duration,
-    expectedActivities: workPackage.expectedActivities.map(descriptionBulletTransformer),
-    deliverables: workPackage.deliverables.map(descriptionBulletTransformer),
-    dependencies: workPackage.dependencies.map(wbsNumOf),
-    projectManager: wbsElement.projectManager ?? undefined,
-    projectLead: wbsElement.projectLead ?? undefined,
-    status: convertStatus(wbsElement.status),
+    id: wpInput.workPackageId,
+    dateCreated: wpInput.wbsElement.dateCreated,
+    name: wpInput.wbsElement.name,
+    orderInProject: wpInput.orderInProject,
+    progress: wpInput.progress,
+    startDate: wpInput.startDate,
+    duration: wpInput.duration,
+    expectedActivities: wpInput.expectedActivities.map(descriptionBulletTransformer),
+    deliverables: wpInput.deliverables.map(descriptionBulletTransformer),
+    dependencies: wpInput.dependencies.map(wbsNumOf),
+    projectManager: wpInput.wbsElement.projectManager ?? undefined,
+    projectLead: wpInput.wbsElement.projectLead ?? undefined,
+    status: convertStatus(wpInput.wbsElement.status),
     wbsNum,
-    endDate: calculateEndDate(workPackage.startDate, workPackage.duration),
+    endDate: calculateEndDate(wpInput.startDate, wpInput.duration),
     expectedProgress,
-    timelineStatus: calculateTimelineStatus(workPackage.progress, expectedProgress),
-    changes: wbsElement.changes.map((change) => ({
+    timelineStatus: calculateTimelineStatus(wpInput.progress, expectedProgress),
+    changes: wpInput.wbsElement.changes.map((change) => ({
       wbsNum,
       changeId: change.changeId,
       changeRequestId: change.changeRequestId,
@@ -119,12 +101,12 @@ const workPackageTransformer = (
       detail: change.detail,
       dateImplemented: change.dateImplemented
     }))
-  };
+  } as WorkPackage;
 };
 
 // Fetch all work packages
 const getAllWorkPackages: ApiRouteFunction = async () => {
-  const workPackages = await prisma.work_Package.findMany(manyRelationArgs);
+  const workPackages = await prisma.work_Package.findMany(wpQueryArgs);
   return buildSuccessResponse(workPackages.map(workPackageTransformer));
 };
 
@@ -134,20 +116,18 @@ const getSingleWorkPackage: ApiRouteFunction = async (params: { wbsNum: string }
   if (isProject(parsedWbs)) {
     return buildClientFailureResponse('WBS Number is a project WBS#, not a Work Package WBS#');
   }
-  const wbsEle = await prisma.wBS_Element.findUnique({
+  const wp = await prisma.work_Package.findFirst({
     where: {
-      wbsNumber: {
+      wbsElement: {
         carNumber: parsedWbs.carNumber,
         projectNumber: parsedWbs.projectNumber,
         workPackageNumber: parsedWbs.workPackageNumber
       }
     },
-    ...uniqueRelationArgs
+    ...wpQueryArgs
   });
-  if (wbsEle === null) {
-    return buildNotFoundResponse('work package', `WBS # ${params.wbsNum}`);
-  }
-  return buildSuccessResponse(workPackageTransformer(wbsEle));
+  if (wp === null) return buildNotFoundResponse('work package', `WBS # ${params.wbsNum}`);
+  return buildSuccessResponse(workPackageTransformer(wp));
 };
 
 // Fetch all work packages with an end date in the next 2 weeks
@@ -158,7 +138,7 @@ const getAllWorkPackagesUpcomingDeadlines: ApiRouteFunction = async () => {
         status: WBS_Element_Status.ACTIVE
       }
     },
-    ...manyRelationArgs
+    ...wpQueryArgs
   });
   const outputWorkPackages = workPackages
     .filter((wp) => {

--- a/src/frontend/pages/HomePage/home.test.tsx
+++ b/src/frontend/pages/HomePage/home.test.tsx
@@ -6,6 +6,10 @@
 import { render, screen, routerWrapperBuilder } from '../../../test-support/test-utils';
 import { routes } from '../../../shared/routes';
 import Home from './home';
+import { useAuth } from '../../../services/auth.hooks';
+import { Auth } from '../../../shared/types';
+import { exampleAdminUser } from '../../../test-support/test-data/users.stub';
+import { mockAuth } from '../../../test-support/test-data/test-utils.stub';
 
 jest.mock('./useful-links/useful-links', () => {
   return {
@@ -25,6 +29,23 @@ jest.mock('./upcoming-deadlines/upcoming-deadlines', () => {
   };
 });
 
+jest.mock('./work-packages-by-timeline-status/work-packages-by-timeline-status', () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <div>work-packages-by-timeline-status</div>;
+    }
+  };
+});
+
+jest.mock('../../../services/auth.hooks');
+
+const mockedUseAuth = useAuth as jest.Mock<Auth>;
+
+const mockAuthHook = (user = exampleAdminUser) => {
+  mockedUseAuth.mockReturnValue(mockAuth(false, user));
+};
+
 /**
  * Sets up the component under test with the desired values and renders it.
  */
@@ -38,9 +59,13 @@ const renderComponent = () => {
 };
 
 describe('home component', () => {
+  beforeEach(() => {
+    mockAuthHook();
+  });
+
   it('renders welcome', () => {
     renderComponent();
-    expect(screen.getByText(/Welcome/i)).toBeInTheDocument();
+    expect(screen.getByText(`Welcome, ${exampleAdminUser.firstName}!`)).toBeInTheDocument();
   });
 
   it('renders useful links', () => {
@@ -51,5 +76,10 @@ describe('home component', () => {
   it('renders upcoming deadlines', () => {
     renderComponent();
     expect(screen.getByText('upcoming-deadlines')).toBeInTheDocument();
+  });
+
+  it('renders work packages by timeline status', () => {
+    renderComponent();
+    expect(screen.getByText('work-packages-by-timeline-status')).toBeInTheDocument();
   });
 });

--- a/src/frontend/pages/HomePage/home.tsx
+++ b/src/frontend/pages/HomePage/home.tsx
@@ -6,6 +6,7 @@
 import { Container } from 'react-bootstrap';
 import { useAuth } from '../../../services/auth.hooks';
 import UsefulLinks from './useful-links/useful-links';
+import WorkPackagesByTimelineStatus from './work-packages-by-timeline-status/work-packages-by-timeline-status';
 import UpcomingDeadlines from './upcoming-deadlines/upcoming-deadlines';
 import styles from './home.module.css';
 
@@ -16,6 +17,7 @@ const Home: React.FC = () => {
       <h1 className={styles.title}>Welcome, {auth.user?.firstName}!</h1>
       <UsefulLinks />
       <UpcomingDeadlines />
+      <WorkPackagesByTimelineStatus />
     </Container>
   );
 };

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.module.css
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.module.css
@@ -1,0 +1,9 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+ .workPackageCard {
+  min-width: fit-content !important;
+  margin: 0px 10px 10px 0px;
+ }

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.test.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { UseQueryResult } from 'react-query';
+import { WorkPackage } from 'utils';
+import { useAllWorkPackages } from '../../../../services/work-packages.hooks';
+import { datePipe, fullNamePipe } from '../../../../shared/pipes';
+import { mockUseQueryResult } from '../../../../test-support/test-data/test-utils.stub';
+import { exampleAllWorkPackages } from '../../../../test-support/test-data/work-packages.stub';
+import { render, routerWrapperBuilder, screen } from '../../../../test-support/test-utils';
+import WorkPackagesByTimelineStatus from './work-packages-by-timeline-status';
+
+jest.mock('../../../../services/work-packages.hooks');
+
+const mockedUseAllWPs = useAllWorkPackages as jest.Mock<UseQueryResult<WorkPackage[]>>;
+
+const mockHook = (isLoading: boolean, isError: boolean, data?: WorkPackage[], error?: Error) => {
+  mockedUseAllWPs.mockReturnValue(
+    mockUseQueryResult<WorkPackage[]>(isLoading, isError, data, error)
+  );
+};
+
+/**
+ * Sets up the component under test with the desired values and renders it.
+ */
+const renderComponent = () => {
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <WorkPackagesByTimelineStatus />
+    </RouterWrapper>
+  );
+};
+
+describe('upcoming deadlines component', () => {
+  it('renders headers', () => {
+    mockHook(false, false, []);
+    renderComponent();
+    expect(screen.getByText('Work Packages By Timeline Status')).toBeInTheDocument();
+  });
+
+  it('renders loading indicator', () => {
+    mockHook(true, false);
+    renderComponent();
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('handles the api throwing an error', () => {
+    mockHook(false, true, undefined, new Error('out of bounds error'));
+    renderComponent();
+    expect(screen.getByText('Oops, sorry!')).toBeInTheDocument();
+    expect(screen.getByText('out of bounds error')).toBeInTheDocument();
+  });
+
+  it('renders the work packages', () => {
+    mockHook(false, false, exampleAllWorkPackages);
+    renderComponent();
+    expect(screen.getByText(exampleAllWorkPackages[0].name, { exact: false })).toBeInTheDocument();
+    expect(
+      screen.getByText(fullNamePipe(exampleAllWorkPackages[0].projectLead), { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText(exampleAllWorkPackages[1].name, { exact: false })).toBeInTheDocument();
+    expect(
+      screen.getByText(fullNamePipe(exampleAllWorkPackages[2].projectManager), { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Expected Activities/).length).toEqual(3);
+    expect(
+      screen.getByText(datePipe(exampleAllWorkPackages[1].endDate), { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it('renders when no work packages', () => {
+    mockHook(false, false, []);
+    renderComponent();
+    expect(screen.getByText('No VERY_BEHIND work packages')).toBeInTheDocument();
+  });
+
+  it('renders timeline status selector', () => {
+    mockHook(false, false, exampleAllWorkPackages);
+    renderComponent();
+    expect(screen.getByText('Status:')).toBeInTheDocument();
+    expect(screen.getByText('VERY_BEHIND')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
@@ -1,0 +1,96 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { useState, useEffect } from 'react';
+import { Card, Container, Form, Row } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import { TimelineStatus, WbsElementStatus } from 'utils';
+import { useTheme } from '../../../../services/theme.hooks';
+import { useAllWorkPackages } from '../../../../services/work-packages.hooks';
+import { datePipe, wbsPipe, fullNamePipe, percentPipe } from '../../../../shared/pipes';
+import { routes } from '../../../../shared/routes';
+import LoadingIndicator from '../../../components/loading-indicator/loading-indicator';
+import PageBlock from '../../../layouts/page-block/page-block';
+import ErrorPage from '../../ErrorPage/error-page';
+import styles from './work-packages-by-timeline-status.module.css';
+
+const WorkPackagesByTimelineStatus: React.FC = () => {
+  const [timelineStatus, setTimelineStatus] = useState<TimelineStatus>(TimelineStatus.VeryBehind);
+  const theme = useTheme();
+  const workPackages = useAllWorkPackages(WbsElementStatus.Active, timelineStatus);
+
+  useEffect(() => {
+    workPackages.refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timelineStatus]);
+
+  if (workPackages.isError) {
+    return <ErrorPage message={workPackages.error.message} error={workPackages.error} />;
+  }
+
+  const fullDisplay = (
+    <Row className="flex-nowrap overflow-auto justify-content-start">
+      {workPackages.data?.length === 0
+        ? `No ${timelineStatus} work packages`
+        : workPackages.data?.map((wp) => (
+            <Card className={styles.workPackageCard} border={theme.cardBorder} bg={theme.cardBg}>
+              <Card.Body className="p-3">
+                <Card.Title className="mb-2">
+                  <Link to={`${routes.PROJECTS}/${wbsPipe(wp.wbsNum)}`}>
+                    {wbsPipe(wp.wbsNum)} - {wp.name}
+                  </Link>
+                </Card.Title>
+                <Card.Text>
+                  <Container fluid>
+                    <Row className="pb-1">End Date: {datePipe(wp.endDate)}</Row>
+                    <Row className="pb-1">
+                      Progress: {percentPipe(wp.progress)}, {wp.timelineStatus}
+                    </Row>
+                    <Row className="pb-1">Engineering Lead: {fullNamePipe(wp.projectLead)}</Row>
+                    <Row className="pb-1">Project Manager: {fullNamePipe(wp.projectManager)}</Row>
+                    <Row>
+                      {wp.expectedActivities.length} Expected Activities, {wp.deliverables.length}{' '}
+                      Deliverables
+                    </Row>
+                  </Container>
+                </Card.Text>
+              </Card.Body>
+            </Card>
+          ))}
+    </Row>
+  );
+
+  return (
+    <PageBlock
+      title={'Work Packages By Timeline Status'}
+      headerRight={
+        <div className="d-flex flex-row align-items-center">
+          <div className="pr-2">Status:</div>
+          <Form.Control
+            as="select"
+            onChange={(e) => setTimelineStatus(e.target.value as TimelineStatus)}
+            custom
+          >
+            <option key={timelineStatus} value={timelineStatus}>
+              {timelineStatus}
+            </option>
+            {Object.values(TimelineStatus)
+              .filter((status) => status !== timelineStatus)
+              .map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+          </Form.Control>
+        </div>
+      }
+      body={
+        <Container fluid>{workPackages.isLoading ? <LoadingIndicator /> : fullDisplay}</Container>
+      }
+    />
+  );
+};
+
+export default WorkPackagesByTimelineStatus;

--- a/src/services/work-packages.api.ts
+++ b/src/services/work-packages.api.ts
@@ -4,7 +4,14 @@
  */
 
 import axios from 'axios';
-import { CreateWorkPackagePayload, EditWorkPackagePayload, WbsNumber, WorkPackage } from 'utils';
+import {
+  CreateWorkPackagePayload,
+  EditWorkPackagePayload,
+  TimelineStatus,
+  WbsElementStatus,
+  WbsNumber,
+  WorkPackage
+} from 'utils';
 import { wbsPipe } from '../shared/pipes';
 import { apiUrls } from '../shared/urls';
 import { workPackageTransformer } from './transformers/work-packages.transformers';
@@ -12,8 +19,8 @@ import { workPackageTransformer } from './transformers/work-packages.transformer
 /**
  * Fetch all work packages.
  */
-export const getAllWorkPackages = () => {
-  return axios.get<WorkPackage[]>(apiUrls.workPackages(), {
+export const getAllWorkPackages = (status?: WbsElementStatus, timelineStatus?: TimelineStatus) => {
+  return axios.get<WorkPackage[]>(apiUrls.workPackages(status, timelineStatus), {
     transformResponse: (data) => JSON.parse(data).map(workPackageTransformer)
   });
 };

--- a/src/services/work-packages.hooks.ts
+++ b/src/services/work-packages.hooks.ts
@@ -4,8 +4,14 @@
  */
 
 import { useMutation, useQuery } from 'react-query';
-import { WorkPackage, WbsNumber, CreateWorkPackagePayload, EditWorkPackagePayload } from 'utils';
-
+import {
+  WorkPackage,
+  WbsNumber,
+  CreateWorkPackagePayload,
+  EditWorkPackagePayload,
+  WbsElementStatus,
+  TimelineStatus
+} from 'utils';
 import {
   createSingleWorkPackage,
   editWorkPackage,
@@ -17,9 +23,9 @@ import {
 /**
  * Custom React Hook to supply all work packages.
  */
-export const useAllWorkPackages = () => {
+export const useAllWorkPackages = (status?: WbsElementStatus, timelineStatus?: TimelineStatus) => {
   return useQuery<WorkPackage[], Error>(['work packages'], async () => {
-    const { data } = await getAllWorkPackages();
+    const { data } = await getAllWorkPackages(status, timelineStatus);
     return data;
   });
 };

--- a/src/shared/urls.ts
+++ b/src/shared/urls.ts
@@ -21,7 +21,11 @@ const projectsCreate = () => `${projects()}-new`;
 const projectsEdit = () => `${projects()}-edit`;
 
 /**************** Work Packages Endpoint ****************/
-const workPackages = () => `${API_URL}/work-packages`;
+const workPackages = (status?: string, timelineStatus?: string) => {
+  const base = `${API_URL}/work-packages`;
+  if (status && timelineStatus) return `${base}?status=${status}&timelineStatus=${timelineStatus}`;
+  return base;
+};
 const workPackagesByWbsNum = (wbsNum: string) => `${workPackages()}/${wbsNum}`;
 const workPackagesUpcomingDeadlines = () => `${workPackages()}/upcoming-deadlines`;
 const workPackagesCreate = () => `${workPackages()}-create`;


### PR DESCRIPTION
## Changes

Expanded the existing work packages get all endpoint to support optional filtering by status and/or timeline status, not via Prisma implementation. Expanded get all work packages hook to support this filtering. Use this filtering to add a "Work Packages by Timeline Status" component to the home page which not only displays all "VERY_BEHIND" work packages by default, but also allows users to select to see work packages with a different timeline status. Uses the same horizontal scroll card format as the upcoming deadlines component.

## Notes

Okay so this one was interestingly tough. I first filtered client-side until I realized that messes up the loading and isn't so proper, then considered a whole new endpoint, but decided not to. I experiment and researched and built out a flexible addition to the get all work packages endpoint that filters by status or timeline status or both. Considered doing a [Prisma AND NOT](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#get-all-post-records-where-the-title-field-contains-prisma-or-databases-but-not-sql-and-the-related-user-record-email-address-does-not-contain-sarah) implementation as suggested by [their example](https://github.com/prisma/prisma-examples/blob/0a019138e08412de13e3c5889a959d0afed0253e/typescript/rest-express/src/index.ts#L120), but decided that such an implementation would be way more lines of code and would probably only provide slight performance benefits and so I stuck with js `.filter()`.

Then when trying to get the select dropdown to work properly, I discovered that `setState()` is async but doesn't provide a callback parameter like the React docs seem to indicate. Weird. Instead I had to use a `useEffect` with suppressing exhaustive dependencies to have the component re-fetch data and re-render consistently when the dropdown is changed. Seems strange that this is what's required for that to work but I guess the optimizations avoid re-render so this is what's needed. 

I kinda randomly decided to remove duplication by switching the get single work package endpoint to use `findFirst` instead of `findUnique`, allowing us to search via the work package model instead of the wbsElement model while achieving the exact same results.

Not for this PR but considering also doing:
- move WP count into the page block title as `... (6)` for upcoming deadlines
- add WP count into the page block title for this new component
- make upcoming deadlines more flexible and able to support variable "days until deadline" instead of fixed at 14 days

## Test Cases

pretty basic, just tried to maintain test coverage.

## Screenshots (if applicable)

<img width="1396" alt="Screen Shot 2022-06-19 at 12 56 40 AM" src="https://user-images.githubusercontent.com/51571627/174466559-fb8c69f0-6f4b-4ebe-a80b-7fa2d6f634e1.png">

<img width="1312" alt="Screen Shot 2022-06-19 at 12 57 09 AM" src="https://user-images.githubusercontent.com/51571627/174466569-82d08d82-12d1-45a9-9fee-9ea0b3f0b18a.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #729 
