### PR TITLE
#729 home adjustments

### DIFF
--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -118,6 +118,7 @@ const getAllWorkPackages: ApiRouteFunction = async (_, event) => {
     }
     return passes;
   });
+  outputWorkPackages.sort((wpA, wpB) => wpA.endDate.getTime() - wpB.endDate.getTime());
   return buildSuccessResponse(outputWorkPackages);
 };
 

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -39,7 +39,7 @@ const wpQueryArgs = Prisma.validator<Prisma.Work_PackageArgs>()({
       include: {
         projectLead: true,
         projectManager: true,
-        changes: { include: { implementer: true } }
+        changes: { include: { implementer: true }, orderBy: { dateImplemented: 'asc' } }
       }
     },
     expectedActivities: true,

--- a/src/backend/functions/work-packages.ts
+++ b/src/backend/functions/work-packages.ts
@@ -104,7 +104,7 @@ const workPackageTransformer = (wpInput: Prisma.Work_PackageGetPayload<typeof wp
   } as WorkPackage;
 };
 
-// Fetch all work packages
+// Fetch all work packages, optionally filtered by query parameters
 const getAllWorkPackages: ApiRouteFunction = async (_, event) => {
   const { queryStringParameters: eQSP } = event;
   const workPackages = await prisma.work_Package.findMany(wpQueryArgs);
@@ -142,38 +142,12 @@ const getSingleWorkPackage: ApiRouteFunction = async (params: { wbsNum: string }
   return buildSuccessResponse(workPackageTransformer(wp));
 };
 
-// Fetch all work packages with an end date in the next 2 weeks
-const getAllWorkPackagesUpcomingDeadlines: ApiRouteFunction = async () => {
-  const workPackages = await prisma.work_Package.findMany({
-    where: {
-      wbsElement: {
-        status: WBS_Element_Status.ACTIVE
-      }
-    },
-    ...wpQueryArgs
-  });
-  const outputWorkPackages = workPackages
-    .filter((wp) => {
-      const endDate = calculateEndDate(wp.startDate, wp.duration);
-      const daysFromNow = Math.round((endDate.getTime() - new Date().getTime()) / 86400000);
-      return daysFromNow <= 14;
-    })
-    .map(workPackageTransformer);
-  outputWorkPackages.sort((wpA, wpB) => wpA.endDate.getTime() - wpB.endDate.getTime());
-  return buildSuccessResponse(outputWorkPackages);
-};
-
 // Define all valid routes for the endpoint
 const routes: ApiRoute[] = [
   {
     path: `${API_URL}${apiRoutes.WORK_PACKAGES}`,
     httpMethod: 'GET',
     func: getAllWorkPackages
-  },
-  {
-    path: `${API_URL}${apiRoutes.WORK_PACKAGES_UPCOMING_DEADLINES}`,
-    httpMethod: 'GET',
-    func: getAllWorkPackagesUpcomingDeadlines
   },
   {
     path: `${API_URL}${apiRoutes.WORK_PACKAGES_BY_WBS}`,

--- a/src/frontend/layouts/nav-top-bar/nav-top-bar.tsx
+++ b/src/frontend/layouts/nav-top-bar/nav-top-bar.tsx
@@ -6,13 +6,13 @@
 import { Dropdown, Nav, Navbar } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { routes } from '../../../shared/routes';
-import NavUserMenu from './nav-user-menu/nav-user-menu';
-import NavNotificationsMenu from './nav-notifications-menu/nav-notifications-menu';
-import styles from './nav-top-bar.module.css';
 import { useAuth } from '../../../services/auth.hooks';
 import { fullNamePipe } from '../../../shared/pipes';
 import { useTheme } from '../../../services/theme.hooks';
 import themes from '../../../shared/themes';
+import NavUserMenu from './nav-user-menu/nav-user-menu';
+import NavNotificationsMenu from './nav-notifications-menu/nav-notifications-menu';
+import styles from './nav-top-bar.module.css';
 
 const NavTopBar: React.FC = () => {
   const auth = useAuth();
@@ -39,7 +39,9 @@ const NavTopBar: React.FC = () => {
               {themes
                 .filter((t) => t.name !== theme.name)
                 .map((t) => (
-                  <Dropdown.Item onClick={() => theme.toggleTheme!(t.name)}>{t.name}</Dropdown.Item>
+                  <Dropdown.Item key={t.name} onClick={() => theme.toggleTheme!(t.name)}>
+                    {t.name}
+                  </Dropdown.Item>
                 ))}
             </Dropdown.Menu>
           </Dropdown>

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.test.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.test.tsx
@@ -5,7 +5,7 @@
 
 import { UseQueryResult } from 'react-query';
 import { WorkPackage } from 'utils';
-import { useAllWorkPackagesUpcomingDeadlines } from '../../../../services/work-packages.hooks';
+import { useAllWorkPackages } from '../../../../services/work-packages.hooks';
 import { datePipe, fullNamePipe } from '../../../../shared/pipes';
 import { mockUseQueryResult } from '../../../../test-support/test-data/test-utils.stub';
 import { exampleAllWorkPackages } from '../../../../test-support/test-data/work-packages.stub';
@@ -14,9 +14,7 @@ import UpcomingDeadlines from './upcoming-deadlines';
 
 jest.mock('../../../../services/work-packages.hooks');
 
-const mockedUseAllWPs = useAllWorkPackagesUpcomingDeadlines as jest.Mock<
-  UseQueryResult<WorkPackage[]>
->;
+const mockedUseAllWPs = useAllWorkPackages as jest.Mock<UseQueryResult<WorkPackage[]>>;
 
 const mockHook = (isLoading: boolean, isError: boolean, data?: WorkPackage[], error?: Error) => {
   mockedUseAllWPs.mockReturnValue(

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.test.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.test.tsx
@@ -76,4 +76,12 @@ describe('upcoming deadlines component', () => {
     renderComponent();
     expect(screen.getByText('No upcoming deadlines')).toBeInTheDocument();
   });
+
+  it('renders time period selector', () => {
+    mockHook(false, false, exampleAllWorkPackages);
+    renderComponent();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+    expect(screen.getByText('14')).toBeInTheDocument();
+    expect(screen.getByText('Days')).toBeInTheDocument();
+  });
 });

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.test.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.test.tsx
@@ -40,7 +40,7 @@ describe('upcoming deadlines component', () => {
   it('renders headers', () => {
     mockHook(false, false, []);
     renderComponent();
-    expect(screen.getByText('Upcoming Deadlines')).toBeInTheDocument();
+    expect(screen.getByText('Upcoming Deadlines (0)')).toBeInTheDocument();
   });
 
   it('renders loading indicator', () => {
@@ -77,11 +77,5 @@ describe('upcoming deadlines component', () => {
     mockHook(false, false, []);
     renderComponent();
     expect(screen.getByText('No upcoming deadlines')).toBeInTheDocument();
-  });
-
-  it('renders work package count', () => {
-    mockHook(false, false, exampleAllWorkPackages);
-    renderComponent();
-    expect(screen.getByText('3 Work Packages')).toBeInTheDocument();
   });
 });

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
@@ -17,7 +17,10 @@ import styles from './upcoming-deadlines.module.css';
 
 const UpcomingDeadlines: React.FC = () => {
   const theme = useTheme();
-  const workPackages = useAllWorkPackages(WbsElementStatus.Active, undefined, 14);
+  const workPackages = useAllWorkPackages({
+    status: WbsElementStatus.Active,
+    daysUntilDeadline: '14'
+  });
 
   if (workPackages.isError) {
     return <ErrorPage message={workPackages.error.message} error={workPackages.error} />;

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
@@ -31,6 +31,7 @@ const UpcomingDeadlines: React.FC = () => {
         ? 'No upcoming deadlines'
         : workPackages.data?.map((wp) => (
             <Card
+              key={wbsPipe(wp.wbsNum)}
               className={styles.upcomingDeadlineCard}
               border={theme.cardBorder}
               bg={theme.cardBg}

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
@@ -3,7 +3,8 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { Card, Container, Row } from 'react-bootstrap';
+import { useState } from 'react';
+import { Card, Container, Form, InputGroup, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { WbsElementStatus } from 'utils';
 import { useTheme } from '../../../../services/theme.hooks';
@@ -16,11 +17,9 @@ import ErrorPage from '../../ErrorPage/error-page';
 import styles from './upcoming-deadlines.module.css';
 
 const UpcomingDeadlines: React.FC = () => {
+  const [daysUntilDeadline, setDaysUntilDeadline] = useState<string>('14');
   const theme = useTheme();
-  const workPackages = useAllWorkPackages({
-    status: WbsElementStatus.Active,
-    daysUntilDeadline: '14'
-  });
+  const workPackages = useAllWorkPackages({ status: WbsElementStatus.Active, daysUntilDeadline });
 
   if (workPackages.isError) {
     return <ErrorPage message={workPackages.error.message} error={workPackages.error} />;
@@ -65,7 +64,28 @@ const UpcomingDeadlines: React.FC = () => {
   return (
     <PageBlock
       title={`Upcoming Deadlines (${workPackages.data?.length})`}
-      headerRight={<></>}
+      headerRight={
+        <InputGroup>
+          <InputGroup.Prepend>
+            <InputGroup.Text>Next</InputGroup.Text>
+          </InputGroup.Prepend>
+          <Form.Control
+            custom
+            as="select"
+            value={daysUntilDeadline}
+            onChange={(e) => setDaysUntilDeadline(e.target.value)}
+          >
+            {['1', '2', '5', '7', '14', '21', '30'].map((days) => (
+              <option key={days} value={days}>
+                {days}
+              </option>
+            ))}
+          </Form.Control>
+          <InputGroup.Append>
+            <InputGroup.Text>Days</InputGroup.Text>
+          </InputGroup.Append>
+        </InputGroup>
+      }
       body={
         <Container fluid>{workPackages.isLoading ? <LoadingIndicator /> : fullDisplay}</Container>
       }

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
@@ -5,8 +5,9 @@
 
 import { Card, Container, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import { WbsElementStatus } from 'utils';
 import { useTheme } from '../../../../services/theme.hooks';
-import { useAllWorkPackagesUpcomingDeadlines } from '../../../../services/work-packages.hooks';
+import { useAllWorkPackages } from '../../../../services/work-packages.hooks';
 import { datePipe, wbsPipe, fullNamePipe, percentPipe } from '../../../../shared/pipes';
 import { routes } from '../../../../shared/routes';
 import LoadingIndicator from '../../../components/loading-indicator/loading-indicator';
@@ -16,7 +17,7 @@ import styles from './upcoming-deadlines.module.css';
 
 const UpcomingDeadlines: React.FC = () => {
   const theme = useTheme();
-  const workPackages = useAllWorkPackagesUpcomingDeadlines();
+  const workPackages = useAllWorkPackages(WbsElementStatus.Active, undefined, 14);
 
   if (workPackages.isError) {
     return <ErrorPage message={workPackages.error.message} error={workPackages.error} />;

--- a/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
+++ b/src/frontend/pages/HomePage/upcoming-deadlines/upcoming-deadlines.tsx
@@ -60,8 +60,8 @@ const UpcomingDeadlines: React.FC = () => {
 
   return (
     <PageBlock
-      title={'Upcoming Deadlines'}
-      headerRight={workPackages.isLoading ? <></> : <>{workPackages.data?.length} Work Packages</>}
+      title={`Upcoming Deadlines (${workPackages.data?.length})`}
+      headerRight={<></>}
       body={
         <Container fluid>{workPackages.isLoading ? <LoadingIndicator /> : fullDisplay}</Container>
       }

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.test.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.test.tsx
@@ -38,7 +38,7 @@ describe('upcoming deadlines component', () => {
   it('renders headers', () => {
     mockHook(false, false, []);
     renderComponent();
-    expect(screen.getByText('Work Packages By Timeline Status')).toBeInTheDocument();
+    expect(screen.getByText('Work Packages By Timeline Status (0)')).toBeInTheDocument();
   });
 
   it('renders loading indicator', () => {

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.test.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.test.tsx
@@ -80,7 +80,7 @@ describe('upcoming deadlines component', () => {
   it('renders timeline status selector', () => {
     mockHook(false, false, exampleAllWorkPackages);
     renderComponent();
-    expect(screen.getByText('Status:')).toBeInTheDocument();
+    expect(screen.getByText('Timeline Status')).toBeInTheDocument();
     expect(screen.getByText('VERY_BEHIND')).toBeInTheDocument();
   });
 });

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
@@ -35,7 +35,12 @@ const WorkPackagesByTimelineStatus: React.FC = () => {
       {workPackages.data?.length === 0
         ? `No ${timelineStatus} work packages`
         : workPackages.data?.map((wp) => (
-            <Card className={styles.workPackageCard} border={theme.cardBorder} bg={theme.cardBg}>
+            <Card
+              key={wbsPipe(wp.wbsNum)}
+              className={styles.workPackageCard}
+              border={theme.cardBorder}
+              bg={theme.cardBg}
+            >
               <Card.Body className="p-3">
                 <Card.Title className="mb-2">
                   <Link to={`${routes.PROJECTS}/${wbsPipe(wp.wbsNum)}`}>

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
@@ -64,7 +64,7 @@ const WorkPackagesByTimelineStatus: React.FC = () => {
 
   return (
     <PageBlock
-      title={'Work Packages By Timeline Status'}
+      title={`Work Packages By Timeline Status (${workPackages.data?.length})`}
       headerRight={
         <div className="d-flex flex-row align-items-center">
           <div className="pr-2">Status:</div>

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Card, Container, Form, Row } from 'react-bootstrap';
+import { Card, Container, Form, InputGroup, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { TimelineStatus, WbsElementStatus } from 'utils';
 import { useTheme } from '../../../../services/theme.hooks';
@@ -66,10 +66,13 @@ const WorkPackagesByTimelineStatus: React.FC = () => {
     <PageBlock
       title={`Work Packages By Timeline Status (${workPackages.data?.length})`}
       headerRight={
-        <div className="d-flex flex-row align-items-center">
-          <div className="pr-2">Status:</div>
+        <InputGroup>
+          <InputGroup.Prepend>
+            <InputGroup.Text id="selectTimelineStatus">Timeline Status</InputGroup.Text>
+          </InputGroup.Prepend>
           <Form.Control
             as="select"
+            aria-describedby="selectTimelineStatus"
             onChange={(e) => setTimelineStatus(e.target.value as TimelineStatus)}
             custom
           >
@@ -84,7 +87,7 @@ const WorkPackagesByTimelineStatus: React.FC = () => {
                 </option>
               ))}
           </Form.Control>
-        </div>
+        </InputGroup>
       }
       body={
         <Container fluid>{workPackages.isLoading ? <LoadingIndicator /> : fullDisplay}</Container>

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
@@ -19,7 +19,7 @@ import styles from './work-packages-by-timeline-status.module.css';
 const WorkPackagesByTimelineStatus: React.FC = () => {
   const [timelineStatus, setTimelineStatus] = useState<TimelineStatus>(TimelineStatus.VeryBehind);
   const theme = useTheme();
-  const workPackages = useAllWorkPackages(WbsElementStatus.Active, timelineStatus);
+  const workPackages = useAllWorkPackages({ status: WbsElementStatus.Active, timelineStatus });
 
   useEffect(() => {
     workPackages.refetch();

--- a/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
+++ b/src/frontend/pages/HomePage/work-packages-by-timeline-status/work-packages-by-timeline-status.tsx
@@ -73,19 +73,15 @@ const WorkPackagesByTimelineStatus: React.FC = () => {
           <Form.Control
             as="select"
             aria-describedby="selectTimelineStatus"
+            value={timelineStatus}
             onChange={(e) => setTimelineStatus(e.target.value as TimelineStatus)}
             custom
           >
-            <option key={timelineStatus} value={timelineStatus}>
-              {timelineStatus}
-            </option>
-            {Object.values(TimelineStatus)
-              .filter((status) => status !== timelineStatus)
-              .map((status) => (
-                <option key={status} value={status}>
-                  {status}
-                </option>
-              ))}
+            {Object.values(TimelineStatus).map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
           </Form.Control>
         </InputGroup>
       }

--- a/src/frontend/pages/LoginPage/login.tsx
+++ b/src/frontend/pages/LoginPage/login.tsx
@@ -28,7 +28,6 @@ const Login: React.FC<LoginProps> = ({ postLoginRedirect }) => {
   if (auth.isLoading) return <LoadingIndicator />;
 
   const redirectAfterLogin = () => {
-    console.log(postLoginRedirect);
     if (postLoginRedirect.url === routes.LOGIN) {
       history.push(routes.HOME);
     } else {

--- a/src/services/work-packages.api.ts
+++ b/src/services/work-packages.api.ts
@@ -4,14 +4,7 @@
  */
 
 import axios from 'axios';
-import {
-  CreateWorkPackagePayload,
-  EditWorkPackagePayload,
-  TimelineStatus,
-  WbsElementStatus,
-  WbsNumber,
-  WorkPackage
-} from 'utils';
+import { CreateWorkPackagePayload, EditWorkPackagePayload, WbsNumber, WorkPackage } from 'utils';
 import { wbsPipe } from '../shared/pipes';
 import { apiUrls } from '../shared/urls';
 import { workPackageTransformer } from './transformers/work-packages.transformers';
@@ -19,17 +12,10 @@ import { workPackageTransformer } from './transformers/work-packages.transformer
 /**
  * Fetch all work packages.
  */
-export const getAllWorkPackages = (
-  status?: WbsElementStatus,
-  timelineStatus?: TimelineStatus,
-  daysUntilDeadline?: number
-) => {
-  return axios.get<WorkPackage[]>(
-    apiUrls.workPackages(status, timelineStatus, daysUntilDeadline?.toString()),
-    {
-      transformResponse: (data) => JSON.parse(data).map(workPackageTransformer)
-    }
-  );
+export const getAllWorkPackages = (queryParams?: { [field: string]: string }) => {
+  return axios.get<WorkPackage[]>(apiUrls.workPackages(queryParams), {
+    transformResponse: (data) => JSON.parse(data).map(workPackageTransformer)
+  });
 };
 
 /**

--- a/src/services/work-packages.api.ts
+++ b/src/services/work-packages.api.ts
@@ -65,12 +65,3 @@ export const editWorkPackage = (payload: EditWorkPackagePayload) => {
     ...payload
   });
 };
-
-/**
- * Fetch all work packages with upcoming deadlines.
- */
-export const getAllWorkPackagesUpcomingDeadlines = () => {
-  return axios.get<WorkPackage[]>(apiUrls.workPackagesUpcomingDeadlines(), {
-    transformResponse: (data) => JSON.parse(data).map(workPackageTransformer)
-  });
-};

--- a/src/services/work-packages.api.ts
+++ b/src/services/work-packages.api.ts
@@ -19,10 +19,17 @@ import { workPackageTransformer } from './transformers/work-packages.transformer
 /**
  * Fetch all work packages.
  */
-export const getAllWorkPackages = (status?: WbsElementStatus, timelineStatus?: TimelineStatus) => {
-  return axios.get<WorkPackage[]>(apiUrls.workPackages(status, timelineStatus), {
-    transformResponse: (data) => JSON.parse(data).map(workPackageTransformer)
-  });
+export const getAllWorkPackages = (
+  status?: WbsElementStatus,
+  timelineStatus?: TimelineStatus,
+  daysUntilDeadline?: number
+) => {
+  return axios.get<WorkPackage[]>(
+    apiUrls.workPackages(status, timelineStatus, daysUntilDeadline?.toString()),
+    {
+      transformResponse: (data) => JSON.parse(data).map(workPackageTransformer)
+    }
+  );
 };
 
 /**

--- a/src/services/work-packages.hooks.ts
+++ b/src/services/work-packages.hooks.ts
@@ -16,7 +16,6 @@ import {
   createSingleWorkPackage,
   editWorkPackage,
   getAllWorkPackages,
-  getAllWorkPackagesUpcomingDeadlines,
   getSingleWorkPackage
 } from './work-packages.api';
 
@@ -28,10 +27,13 @@ export const useAllWorkPackages = (
   timelineStatus?: TimelineStatus,
   daysUntilDeadline?: number
 ) => {
-  return useQuery<WorkPackage[], Error>(['work packages'], async () => {
-    const { data } = await getAllWorkPackages(status, timelineStatus, daysUntilDeadline);
-    return data;
-  });
+  return useQuery<WorkPackage[], Error>(
+    ['work packages', status, timelineStatus, daysUntilDeadline],
+    async () => {
+      const { data } = await getAllWorkPackages(status, timelineStatus, daysUntilDeadline);
+      return data;
+    }
+  );
 };
 
 /**
@@ -79,14 +81,4 @@ export const useEditWorkPackage = () => {
       }
     }
   );
-};
-
-/**
- * Custom React Hook to supply all work packages with an upcoming deadline.
- */
-export const useAllWorkPackagesUpcomingDeadlines = () => {
-  return useQuery<WorkPackage[], Error>(['work packages', 'upcoming deadlines'], async () => {
-    const { data } = await getAllWorkPackagesUpcomingDeadlines();
-    return data;
-  });
 };

--- a/src/services/work-packages.hooks.ts
+++ b/src/services/work-packages.hooks.ts
@@ -23,9 +23,13 @@ import {
 /**
  * Custom React Hook to supply all work packages.
  */
-export const useAllWorkPackages = (status?: WbsElementStatus, timelineStatus?: TimelineStatus) => {
+export const useAllWorkPackages = (
+  status?: WbsElementStatus,
+  timelineStatus?: TimelineStatus,
+  daysUntilDeadline?: number
+) => {
   return useQuery<WorkPackage[], Error>(['work packages'], async () => {
-    const { data } = await getAllWorkPackages(status, timelineStatus);
+    const { data } = await getAllWorkPackages(status, timelineStatus, daysUntilDeadline);
     return data;
   });
 };

--- a/src/services/work-packages.hooks.ts
+++ b/src/services/work-packages.hooks.ts
@@ -4,14 +4,7 @@
  */
 
 import { useMutation, useQuery } from 'react-query';
-import {
-  WorkPackage,
-  WbsNumber,
-  CreateWorkPackagePayload,
-  EditWorkPackagePayload,
-  WbsElementStatus,
-  TimelineStatus
-} from 'utils';
+import { WorkPackage, WbsNumber, CreateWorkPackagePayload, EditWorkPackagePayload } from 'utils';
 import {
   createSingleWorkPackage,
   editWorkPackage,
@@ -22,18 +15,11 @@ import {
 /**
  * Custom React Hook to supply all work packages.
  */
-export const useAllWorkPackages = (
-  status?: WbsElementStatus,
-  timelineStatus?: TimelineStatus,
-  daysUntilDeadline?: number
-) => {
-  return useQuery<WorkPackage[], Error>(
-    ['work packages', status, timelineStatus, daysUntilDeadline],
-    async () => {
-      const { data } = await getAllWorkPackages(status, timelineStatus, daysUntilDeadline);
-      return data;
-    }
-  );
+export const useAllWorkPackages = (queryParams?: { [field: string]: string }) => {
+  return useQuery<WorkPackage[], Error>(['work packages', queryParams], async () => {
+    const { data } = await getAllWorkPackages(queryParams);
+    return data;
+  });
 };
 
 /**

--- a/src/shared/pipes.tsx
+++ b/src/shared/pipes.tsx
@@ -27,7 +27,7 @@ export const linkPipe = (description: string, link: string): ReactElement => {
 
 export const iconLinkPipe = (icon: IconProp, description: string, link: string) => {
   return (
-    <div className="d-flex flex-row align-items-center px-3">
+    <div key={description} className="d-flex flex-row align-items-center px-3">
       <FontAwesomeIcon icon={icon} size="lg" className="pr-1" />
       {linkPipe(description, link)}
     </div>

--- a/src/shared/tests/urls.test.tsx
+++ b/src/shared/tests/urls.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { apiUrls } from '../urls';
+
+describe('API URLs Tests', () => {
+  describe('all work packages urls', () => {
+    it('should return the correct url for all work packages base', () => {
+      expect(apiUrls.workPackages()).toEqual('/.netlify/functions/work-packages');
+    });
+
+    it('should return the correct url for all work packages filtered by status', () => {
+      expect(apiUrls.workPackages({ status: 'ACTIVE' })).toEqual(
+        '/.netlify/functions/work-packages?status=ACTIVE'
+      );
+    });
+
+    it('should return the correct url for all work packages filtered by timelineStatus', () => {
+      expect(apiUrls.workPackages({ timelineStatus: 'BEHIND' })).toEqual(
+        '/.netlify/functions/work-packages?timelineStatus=BEHIND'
+      );
+    });
+
+    it('should return the correct url for all work packages filtered by daysUntilDeadline', () => {
+      expect(apiUrls.workPackages({ daysUntilDeadline: '14' })).toEqual(
+        '/.netlify/functions/work-packages?daysUntilDeadline=14'
+      );
+    });
+
+    it('should return the correct url for all work packages filtered by status and timelineStatus', () => {
+      expect(apiUrls.workPackages({ status: 'ACTIVE', timelineStatus: 'AHEAD' })).toEqual(
+        '/.netlify/functions/work-packages?status=ACTIVE&timelineStatus=AHEAD'
+      );
+    });
+
+    it('should return the correct url for all work packages filtered by status and daysUntilDeadline', () => {
+      expect(apiUrls.workPackages({ status: 'COMPLETE', daysUntilDeadline: '12' })).toEqual(
+        '/.netlify/functions/work-packages?status=COMPLETE&daysUntilDeadline=12'
+      );
+    });
+
+    it('should return the correct url for all work packages filtered by timelineStatus and daysUntilDeadline', () => {
+      expect(
+        apiUrls.workPackages({ timelineStatus: 'VERY_BEHIND', daysUntilDeadline: '10' })
+      ).toEqual(
+        '/.netlify/functions/work-packages?timelineStatus=VERY_BEHIND&daysUntilDeadline=10'
+      );
+    });
+
+    it('should return the correct url for all work packages filtered by status, timelineStatus, and daysUntilDeadline', () => {
+      expect(
+        apiUrls.workPackages({
+          status: 'INACTIVE',
+          timelineStatus: 'ON_TRACK',
+          daysUntilDeadline: '7'
+        })
+      ).toEqual(
+        '/.netlify/functions/work-packages?status=INACTIVE&timelineStatus=ON_TRACK&daysUntilDeadline=7'
+      );
+    });
+  });
+});

--- a/src/shared/urls.ts
+++ b/src/shared/urls.ts
@@ -21,10 +21,12 @@ const projectsCreate = () => `${projects()}-new`;
 const projectsEdit = () => `${projects()}-edit`;
 
 /**************** Work Packages Endpoint ****************/
-const workPackages = (status?: string, timelineStatus?: string) => {
-  const base = `${API_URL}/work-packages`;
-  if (status && timelineStatus) return `${base}?status=${status}&timelineStatus=${timelineStatus}`;
-  return base;
+const workPackages = (status?: string, timelineStatus?: string, daysUntilDeadline?: string) => {
+  let url = `${API_URL}/work-packages`;
+  if (status) url += `?status=${status}&`;
+  if (timelineStatus) url += `timelineStatus=${timelineStatus}&`;
+  if (daysUntilDeadline) url += `daysUntilDeadline=${daysUntilDeadline}`;
+  return url;
 };
 const workPackagesByWbsNum = (wbsNum: string) => `${workPackages()}/${wbsNum}`;
 const workPackagesUpcomingDeadlines = () => `${workPackages()}/upcoming-deadlines`;

--- a/src/shared/urls.ts
+++ b/src/shared/urls.ts
@@ -29,7 +29,6 @@ const workPackages = (status?: string, timelineStatus?: string, daysUntilDeadlin
   return url;
 };
 const workPackagesByWbsNum = (wbsNum: string) => `${workPackages()}/${wbsNum}`;
-const workPackagesUpcomingDeadlines = () => `${workPackages()}/upcoming-deadlines`;
 const workPackagesCreate = () => `${workPackages()}-create`;
 const workPackagesEdit = () => `${workPackages()}-edit`;
 
@@ -54,7 +53,6 @@ export const apiUrls = {
 
   workPackages,
   workPackagesByWbsNum,
-  workPackagesUpcomingDeadlines,
   workPackagesCreate,
   workPackagesEdit,
 

--- a/src/shared/urls.ts
+++ b/src/shared/urls.ts
@@ -21,12 +21,12 @@ const projectsCreate = () => `${projects()}-new`;
 const projectsEdit = () => `${projects()}-edit`;
 
 /**************** Work Packages Endpoint ****************/
-const workPackages = (status?: string, timelineStatus?: string, daysUntilDeadline?: string) => {
-  let url = `${API_URL}/work-packages`;
-  if (status) url += `?status=${status}&`;
-  if (timelineStatus) url += `timelineStatus=${timelineStatus}&`;
-  if (daysUntilDeadline) url += `daysUntilDeadline=${daysUntilDeadline}`;
-  return url;
+const workPackages = (queryParams?: { [field: string]: string }) => {
+  const url = `${API_URL}/work-packages`;
+  if (!queryParams) return url;
+  return `${url}?${Object.keys(queryParams)
+    .map((param) => `${param}=${queryParams[param]}`)
+    .join('&')}`;
 };
 const workPackagesByWbsNum = (wbsNum: string) => `${workPackages()}/${wbsNum}`;
 const workPackagesCreate = () => `${workPackages()}-create`;

--- a/src/utils/src/api-routes.ts
+++ b/src/utils/src/api-routes.ts
@@ -18,7 +18,6 @@ const PROJECTS_EDIT: string = `${PROJECTS}-edit`;
 /**************** Work Packages Endpoint ****************/
 const WORK_PACKAGES: string = `/work-packages`;
 const WORK_PACKAGES_BY_WBS: string = `${WORK_PACKAGES}/:wbsNum`;
-const WORK_PACKAGES_UPCOMING_DEADLINES: string = `${WORK_PACKAGES}/upcoming-deadlines`;
 const WORK_PACKAGES_CREATE: string = `${WORK_PACKAGES}-create`;
 const WORK_PACKAGES_EDIT: string = `${WORK_PACKAGES}-edit`;
 
@@ -39,7 +38,6 @@ export const apiRoutes = {
 
   WORK_PACKAGES,
   WORK_PACKAGES_BY_WBS,
-  WORK_PACKAGES_UPCOMING_DEADLINES,
   WORK_PACKAGES_CREATE,
   WORK_PACKAGES_EDIT,
 


### PR DESCRIPTION
## Changes

Okay so basically I did all the adjustments that I wanted to do from my last PR and some more cuz cleanup is good whatever lol. Turns out I could get rid of the useEffect hook refetch if I just had a flexible object for query parameters instead of function parameters. I expended the work package endpoint to have enough query parameters to replace the separate upcoming deadlines endpoint so that's good. Also had to ensure that query params were included in query keys or else it would use the same resulting data for both instances of the same hook no matter the input. Good to know `react-query` is smart.

## Test Cases

improved testing by testing the url function for work package query parameters urls

## Screenshots (if applicable)

Now that's a proper home page
<img width="1631" alt="Screen Shot 2022-06-19 at 8 26 33 AM" src="https://user-images.githubusercontent.com/51571627/174480848-e2982f1e-5d6a-40e6-8d62-ce8efa89c00a.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #729 
