### PR TITLE
#745 breadcrumbs

### DIFF
--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.module.css
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.module.css
@@ -1,0 +1,4 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */

--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.module.css
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.module.css
@@ -2,3 +2,8 @@
  * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
  * See the LICENSE file in the repository root folder for details.
  */
+
+.breadcrumbs ol {
+    background-color: transparent !important;
+    padding: 0px !important;
+}

--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.test.tsx
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.test.tsx
@@ -4,10 +4,12 @@
  */
 
 import { render, routerWrapperBuilder, screen } from '../../../test-support/test-utils';
+import { testLinkItems } from '../../../test-support/test-data/test-utils.stub';
+import { LinkItem } from '../../../shared/types';
 import PageBreadcrumbs from './page-breadcrumbs';
 
 // Render component under test
-const renderComponent = (title = 'test', pages = []) => {
+const renderComponent = (title = 'test', pages: LinkItem[] = []) => {
   const RouterWrapper = routerWrapperBuilder({});
   return render(
     <RouterWrapper>
@@ -21,9 +23,24 @@ describe('page-breadcrumbs component', () => {
     renderComponent();
   });
 
-  it('renders title', () => {
+  it('renders current page', () => {
     renderComponent();
 
     expect(screen.getByText('test')).toBeInTheDocument();
+  });
+
+  it('renders home by default', () => {
+    renderComponent();
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders provided pages', () => {
+    renderComponent('hello there', testLinkItems);
+
+    expect(screen.getByText('hello there')).toBeInTheDocument();
+    expect(screen.getAllByText('Home').length).toEqual(2);
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+    expect(screen.getByText('Change Requests')).toBeInTheDocument();
   });
 });

--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.test.tsx
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { render, routerWrapperBuilder, screen } from '../../../test-support/test-utils';
+import PageBreadcrumbs from './page-breadcrumbs';
+
+// Render component under test
+const renderComponent = (title = 'test', pages = []) => {
+  const RouterWrapper = routerWrapperBuilder({});
+  return render(
+    <RouterWrapper>
+      <PageBreadcrumbs currentPageTitle={title} previousPages={pages} />
+    </RouterWrapper>
+  );
+};
+
+describe('page-breadcrumbs component', () => {
+  it('renders without error', () => {
+    renderComponent();
+  });
+
+  it('renders title', () => {
+    renderComponent();
+
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.tsx
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.tsx
@@ -4,10 +4,10 @@
  */
 
 import { Link } from 'react-router-dom';
-import { Breadcrumb, Nav } from 'react-bootstrap';
+import { Breadcrumb } from 'react-bootstrap';
 import { LinkItem } from '../../../shared/types';
 import { routes } from '../../../shared/routes';
-import './page-breadcrumbs.module.css';
+import styles from './page-breadcrumbs.module.css';
 
 interface PageTitleProps {
   currentPageTitle: string;
@@ -17,7 +17,7 @@ interface PageTitleProps {
 // Common component for adding breadcrumbs to a page
 const PageBreadcrumbs: React.FC<PageTitleProps> = ({ currentPageTitle, previousPages }) => {
   return (
-    <Breadcrumb className="pt-3" as={Nav}>
+    <Breadcrumb className={`pt-3 ${styles.breadcrumbs}`}>
       <Breadcrumb.Item linkAs={Link} linkProps={{ to: routes.HOME }}>
         Home
       </Breadcrumb.Item>

--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.tsx
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Link } from 'react-router-dom';
-import { Breadcrumb } from 'react-bootstrap';
+import { Breadcrumb, Nav } from 'react-bootstrap';
 import { LinkItem } from '../../../shared/types';
 import { routes } from '../../../shared/routes';
 import './page-breadcrumbs.module.css';
@@ -17,12 +17,12 @@ interface PageTitleProps {
 // Common component for adding breadcrumbs to a page
 const PageBreadcrumbs: React.FC<PageTitleProps> = ({ currentPageTitle, previousPages }) => {
   return (
-    <Breadcrumb>
-      <Breadcrumb.Item linkAs={Link} href={routes.HOME}>
+    <Breadcrumb className="pt-3" as={Nav}>
+      <Breadcrumb.Item linkAs={Link} linkProps={{ to: routes.HOME }}>
         Home
       </Breadcrumb.Item>
       {previousPages.map((page) => (
-        <Breadcrumb.Item linkAs={Link} href={page.route}>
+        <Breadcrumb.Item linkAs={Link} linkProps={{ to: page.route }}>
           {page.name}
         </Breadcrumb.Item>
       ))}

--- a/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.tsx
+++ b/src/frontend/layouts/page-breadcrumbs/page-breadcrumbs.tsx
@@ -1,0 +1,34 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Link } from 'react-router-dom';
+import { Breadcrumb } from 'react-bootstrap';
+import { LinkItem } from '../../../shared/types';
+import { routes } from '../../../shared/routes';
+import './page-breadcrumbs.module.css';
+
+interface PageTitleProps {
+  currentPageTitle: string;
+  previousPages: LinkItem[];
+}
+
+// Common component for adding breadcrumbs to a page
+const PageBreadcrumbs: React.FC<PageTitleProps> = ({ currentPageTitle, previousPages }) => {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.Item linkAs={Link} href={routes.HOME}>
+        Home
+      </Breadcrumb.Item>
+      {previousPages.map((page) => (
+        <Breadcrumb.Item linkAs={Link} href={page.route}>
+          {page.name}
+        </Breadcrumb.Item>
+      ))}
+      <Breadcrumb.Item active>{currentPageTitle}</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+};
+
+export default PageBreadcrumbs;

--- a/src/frontend/layouts/page-title/page-title.tsx
+++ b/src/frontend/layouts/page-title/page-title.tsx
@@ -13,7 +13,7 @@ interface PageTitleProps {
 // Common component for all page titles
 const PageTitle: React.FC<PageTitleProps> = ({ title, actionButton }) => {
   return (
-    <div className={'pt-3 pb-1 d-flex justify-content-between'}>
+    <div className={'pb-1 d-flex justify-content-between'}>
       <h3>{title}</h3>
       <div>{actionButton}</div>
     </div>

--- a/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.test.tsx
+++ b/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.test.tsx
@@ -3,12 +3,13 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { render, routerWrapperBuilder, screen } from '../../../../test-support/test-utils';
-import NavPageLinks, { LinkItem } from './nav-page-links';
 import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';
+import { render, routerWrapperBuilder, screen } from '../../../../test-support/test-utils';
 import { routes } from '../../../../shared/routes';
+import { LinkItem } from '../../../../shared/types';
+import NavPageLinks from './nav-page-links';
 
-const linkItems: LinkItem[] = [
+const testLinkItems: LinkItem[] = [
   {
     name: 'Home',
     icon: faHome,
@@ -33,7 +34,7 @@ const renderComponent = () => {
   const RouterWrapper = routerWrapperBuilder({});
   return render(
     <RouterWrapper>
-      <NavPageLinks linkItems={linkItems} />
+      <NavPageLinks linkItems={testLinkItems} />
     </RouterWrapper>
   );
 };

--- a/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.test.tsx
+++ b/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.test.tsx
@@ -3,29 +3,9 @@
  * See the LICENSE file in the repository root folder for details.
  */
 
-import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';
 import { render, routerWrapperBuilder, screen } from '../../../../test-support/test-utils';
-import { routes } from '../../../../shared/routes';
-import { LinkItem } from '../../../../shared/types';
+import { testLinkItems } from '../../../../test-support/test-data/test-utils.stub';
 import NavPageLinks from './nav-page-links';
-
-const testLinkItems: LinkItem[] = [
-  {
-    name: 'Home',
-    icon: faHome,
-    route: routes.HOME
-  },
-  {
-    name: 'Projects',
-    icon: faFolder,
-    route: routes.PROJECTS
-  },
-  {
-    name: 'Change Requests',
-    icon: faExchangeAlt,
-    route: routes.CHANGE_REQUESTS
-  }
-];
 
 /**
  * Sets up the component under test with the desired values and renders it.

--- a/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.tsx
+++ b/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.tsx
@@ -5,14 +5,8 @@
 
 import { NavLink } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { LinkItem } from '../../../../shared/types';
 import styles from './nav-page-links.module.css';
-
-export interface LinkItem {
-  name: string;
-  icon?: IconProp;
-  route: string;
-}
 
 interface NavPageLinkProps {
   linkItems: LinkItem[];

--- a/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.tsx
+++ b/src/frontend/layouts/sidebar/nav-page-links/nav-page-links.tsx
@@ -10,7 +10,7 @@ import styles from './nav-page-links.module.css';
 
 export interface LinkItem {
   name: string;
-  icon: IconProp;
+  icon?: IconProp;
   route: string;
 }
 
@@ -29,11 +29,15 @@ const NavPageLinks: React.FC<NavPageLinkProps> = ({ linkItems }: NavPageLinkProp
           activeClassName={styles.activeLink}
           exact
         >
-          <FontAwesomeIcon
-            icon={item.icon}
-            size="2x"
-            className={styles.iconsAndText + ' ' + styles.icon}
-          />
+          {item.icon ? (
+            <FontAwesomeIcon
+              icon={item.icon!}
+              size="2x"
+              className={styles.iconsAndText + ' ' + styles.icon}
+            />
+          ) : (
+            ''
+          )}
           <p className={styles.iconsAndText + ' ' + styles.text}>{item.name}</p>
         </NavLink>
       );

--- a/src/frontend/layouts/sidebar/sidebar.tsx
+++ b/src/frontend/layouts/sidebar/sidebar.tsx
@@ -4,15 +4,16 @@
  */
 
 import { Nav } from 'react-bootstrap';
-import styles from './sidebar.module.css';
-import NavPageLinks, { LinkItem } from './nav-page-links/nav-page-links';
-import { routes } from '../../../shared/routes';
 import {
   faExchangeAlt,
   faFolder,
   faHome,
   faQuestionCircle
 } from '@fortawesome/free-solid-svg-icons';
+import { routes } from '../../../shared/routes';
+import { LinkItem } from '../../../shared/types';
+import NavPageLinks from './nav-page-links/nav-page-links';
+import styles from './sidebar.module.css';
 
 const Sidebar: React.FC = () => {
   const linkItems: LinkItem[] = [

--- a/src/frontend/pages/WorkPackageDetailPage/work-package-page.test.tsx
+++ b/src/frontend/pages/WorkPackageDetailPage/work-package-page.test.tsx
@@ -69,7 +69,7 @@ describe('work package container', () => {
     renderComponent();
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    expect(screen.getByText('1.1.1 - Bodywork Concept of Design')).toBeInTheDocument();
+    expect(screen.getAllByText('1.1.1 - Bodywork Concept of Design').length).toEqual(2);
     expect(screen.getByText('Dependencies')).toBeInTheDocument();
     expect(screen.getByText('Expected Activities')).toBeInTheDocument();
     expect(screen.getByText('Deliverables')).toBeInTheDocument();

--- a/src/frontend/pages/WorkPackageDetailPage/work-package-view-container/work-package-view-container.test.tsx
+++ b/src/frontend/pages/WorkPackageDetailPage/work-package-view-container/work-package-view-container.test.tsx
@@ -43,7 +43,7 @@ describe('work package container view', () => {
   it('renders the project', () => {
     renderComponent();
 
-    expect(screen.getByText('1.1.2 - Adhesive Shear Strength Test')).toBeInTheDocument();
+    expect(screen.getAllByText('1.1.2 - Adhesive Shear Strength Test').length).toEqual(2);
     expect(screen.getByText('Dependencies')).toBeInTheDocument();
     expect(screen.getByText('Expected Activities')).toBeInTheDocument();
     expect(screen.getByText('Deliverables')).toBeInTheDocument();

--- a/src/frontend/pages/WorkPackageDetailPage/work-package-view-container/work-package-view-container.tsx
+++ b/src/frontend/pages/WorkPackageDetailPage/work-package-view-container/work-package-view-container.tsx
@@ -82,7 +82,7 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
       <PageBreadcrumbs
         currentPageTitle={pageTitle}
         previousPages={[
-          { name: 'All Projects', route: routes.PROJECTS },
+          { name: 'Projects', route: routes.PROJECTS },
           { name: projectWbsString, route: `${routes.PROJECTS}/${projectWbsString}` }
         ]}
       />

--- a/src/frontend/pages/WorkPackageDetailPage/work-package-view-container/work-package-view-container.tsx
+++ b/src/frontend/pages/WorkPackageDetailPage/work-package-view-container/work-package-view-container.tsx
@@ -16,6 +16,7 @@ import WorkPackageDetails from './work-package-details/work-package-details';
 import ChangesList from '../../../components/changes-list/changes-list';
 import PageTitle from '../../../layouts/page-title/page-title';
 import StageGateWorkPackageModalContainer from '../stage-gate-work-package-modal-container/stage-gate-work-package-modal-container';
+import PageBreadcrumbs from '../../../layouts/page-breadcrumbs/page-breadcrumbs';
 
 interface WorkPackageViewContainerProps {
   workPackage: WorkPackage;
@@ -74,12 +75,18 @@ const WorkPackageViewContainer: React.FC<WorkPackageViewContainerProps> = ({
     </DropdownButton>
   );
 
+  const pageTitle: string = `${wbsPipe(workPackage.wbsNum)} - ${workPackage.name}`;
+  const projectWbsString: string = wbsPipe({ ...workPackage.wbsNum, workPackageNumber: 0 });
   return (
     <Container fluid>
-      <PageTitle
-        title={`${wbsPipe(workPackage.wbsNum)} - ${workPackage.name}`}
-        actionButton={projectActionsDropdown}
+      <PageBreadcrumbs
+        currentPageTitle={pageTitle}
+        previousPages={[
+          { name: 'All Projects', route: routes.PROJECTS },
+          { name: projectWbsString, route: `${routes.PROJECTS}/${projectWbsString}` }
+        ]}
       />
+      <PageTitle title={pageTitle} actionButton={projectActionsDropdown} />
       <WorkPackageDetails workPackage={workPackage} />
       <HorizontalList
         title={'Dependencies'}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,7 @@
  */
 
 import { User } from '@prisma/client';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export interface Auth {
   user: User | undefined;
@@ -19,4 +20,10 @@ export interface Theme {
   bgColor: string;
   cardBg: string;
   cardBorder: string;
+}
+
+export interface LinkItem {
+  name: string;
+  icon?: IconProp;
+  route: string;
 }

--- a/src/test-support/test-data/test-utils.stub.ts
+++ b/src/test-support/test-data/test-utils.stub.ts
@@ -9,7 +9,9 @@ import { UseMutationResult, UseQueryResult } from 'react-query';
 import { User } from '@prisma/client';
 import { ApiRoute, API_URL } from 'utils';
 import { exampleAdminUser } from './users.stub';
-import { Auth } from '../../shared/types';
+import { Auth, LinkItem } from '../../shared/types';
+import { faExchangeAlt, faFolder, faHome } from '@fortawesome/free-solid-svg-icons';
+import { routes } from '../../shared/routes';
 
 export const exampleApiRoutes: ApiRoute[] = [
   {
@@ -155,3 +157,21 @@ export const mockUtils = {
   remove: () => null,
   update: () => null
 };
+
+export const testLinkItems: LinkItem[] = [
+  {
+    name: 'Home',
+    icon: faHome,
+    route: routes.HOME
+  },
+  {
+    name: 'Projects',
+    icon: faFolder,
+    route: routes.PROJECTS
+  },
+  {
+    name: 'Change Requests',
+    icon: faExchangeAlt,
+    route: routes.CHANGE_REQUESTS
+  }
+];


### PR DESCRIPTION
## Changes

Added breadcrumbs to the work package page because work packages are the most stranded page compared to the rest.

## Screenshots (if applicable)

<img width="1631" alt="Screen Shot 2022-06-22 at 10 46 30 AM" src="https://user-images.githubusercontent.com/51571627/175058946-91e0928a-af8a-4ed2-9511-ca699fdfbed2.png">

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes #745 
