### PR TITLE
#709-added-risk-edit-files-with-test

### DIFF
--- a/src/backend/functions/risk-edit.ts
+++ b/src/backend/functions/risk-edit.ts
@@ -23,37 +23,24 @@ const prisma = new PrismaClient();
 export const editRisk: Handler<FromSchema<typeof inputSchema>> = async ({ body }, _context) => {
   const { userId, id, detail, resolved } = body;
 
-  // verify user is allowed to edit work packages
+  // verify user is allowed to edit risk
   const user = await prisma.user.findUnique({ where: { userId } });
   if (!user) return buildNotFoundResponse('user', `#${userId}`);
   if (user.role === Role.GUEST) return buildNoAuthResponse();
 
   // get the original risk and check if it exists
-  const originalRisk = await prisma.risk.findUnique({
-    where: { id }
-  });
-  if (originalRisk === null) {
-    return buildNotFoundResponse('Risk', `#${id}`);
-  }
+  const originalRisk = await prisma.risk.findUnique({ where: { id } });
+  if (!originalRisk) return buildNotFoundResponse('Risk', `#${id}`);
 
   // update the risk with the input fields
   const updatedRisk = await prisma.risk.update({
-    where: {
-      id
-    },
-    data: {
-      detail,
-      isResolved: resolved
-    }
+    where: { id },
+    data: { detail, isResolved: resolved }
   });
 
   // return the updated risk
-  return buildSuccessResponse(updatedRisk);
+  return buildSuccessResponse({ detail: updatedRisk.detail, isResolved: updatedRisk.isResolved });
 };
-
-/**
- * 	HELPER METHODS:
- */
 
 // expected structure of json body
 const inputSchema = eventSchema(riskEditInputSchemaBody);

--- a/src/backend/functions/risk-edit.ts
+++ b/src/backend/functions/risk-edit.ts
@@ -18,46 +18,38 @@ import {
 } from 'utils';
 import { FromSchema } from 'json-schema-to-ts';
 
-const prisma = new PrismaClient(); 
+const prisma = new PrismaClient();
 
-export const editRisk: Handler<FromSchema<typeof inputSchema>> = async (
-	{ body },
-	_context
-) => {
-	const {
-		userId,
-		id, 
-		detail, 
-		resolved
-	} = body; 
-	
-	// verify user is allowed to edit work packages
-	const user = await prisma.user.findUnique({ where: { userId } });
-	if (!user) return buildNotFoundResponse('user', `#${userId}`);
-	if (user.role === Role.GUEST) return buildNoAuthResponse();
+export const editRisk: Handler<FromSchema<typeof inputSchema>> = async ({ body }, _context) => {
+  const { userId, id, detail, resolved } = body;
 
-	// get the original risk and check if it exists
-	const originalRisk = await prisma.risk.findUnique({
-		where: { id },
-	});
-	if (originalRisk === null) {
-		return buildNotFoundResponse('Risk', `#${id}`);
-	}
+  // verify user is allowed to edit work packages
+  const user = await prisma.user.findUnique({ where: { userId } });
+  if (!user) return buildNotFoundResponse('user', `#${userId}`);
+  if (user.role === Role.GUEST) return buildNoAuthResponse();
 
-	// update the risk with the input fields
-	const updatedRisk = await prisma.risk.update({
-		where: { 
-			id
-		},
-		data: {
-			detail,
-			isResolved: resolved
-		}
-	});
+  // get the original risk and check if it exists
+  const originalRisk = await prisma.risk.findUnique({
+    where: { id }
+  });
+  if (originalRisk === null) {
+    return buildNotFoundResponse('Risk', `#${id}`);
+  }
 
-	// return the updated risk 
-	return buildSuccessResponse(updatedRisk); 
-}
+  // update the risk with the input fields
+  const updatedRisk = await prisma.risk.update({
+    where: {
+      id
+    },
+    data: {
+      detail,
+      isResolved: resolved
+    }
+  });
+
+  // return the updated risk
+  return buildSuccessResponse(updatedRisk);
+};
 
 /**
  * 	HELPER METHODS:
@@ -72,5 +64,3 @@ const handler = middy(editRisk)
   .use(httpErrorHandler());
 
 export { handler };
-
-

--- a/src/backend/functions/risk-edit.ts
+++ b/src/backend/functions/risk-edit.ts
@@ -1,0 +1,76 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import middy from '@middy/core';
+import jsonBodyParser from '@middy/http-json-body-parser';
+import httpErrorHandler from '@middy/http-error-handler';
+import validator from '@middy/validator';
+import { Handler } from 'aws-lambda';
+import { PrismaClient, Role } from '@prisma/client';
+import {
+  buildNoAuthResponse,
+  buildNotFoundResponse,
+  buildSuccessResponse,
+  eventSchema,
+  riskEditInputSchemaBody
+} from 'utils';
+import { FromSchema } from 'json-schema-to-ts';
+
+const prisma = new PrismaClient(); 
+
+export const editRisk: Handler<FromSchema<typeof inputSchema>> = async (
+	{ body },
+	_context
+) => {
+	const {
+		userId,
+		id, 
+		detail, 
+		resolved
+	} = body; 
+	
+	// verify user is allowed to edit work packages
+	const user = await prisma.user.findUnique({ where: { userId } });
+	if (!user) return buildNotFoundResponse('user', `#${userId}`);
+	if (user.role === Role.GUEST) return buildNoAuthResponse();
+
+	// get the original risk and check if it exists
+	const originalRisk = await prisma.risk.findUnique({
+		where: { id },
+	});
+	if (originalRisk === null) {
+		return buildNotFoundResponse('Risk', `#${id}`);
+	}
+
+	// update the risk with the input fields
+	const updatedRisk = await prisma.risk.update({
+		where: { 
+			id
+		},
+		data: {
+			detail,
+			isResolved: resolved
+		}
+	});
+
+	// return the updated risk 
+	return buildSuccessResponse(updatedRisk); 
+}
+
+/**
+ * 	HELPER METHODS:
+ */
+
+// expected structure of json body
+const inputSchema = eventSchema(riskEditInputSchemaBody);
+
+const handler = middy(editRisk)
+  .use(jsonBodyParser())
+  .use(validator({ inputSchema }))
+  .use(httpErrorHandler());
+
+export { handler };
+
+

--- a/src/backend/tests/risk-edit.test.ts
+++ b/src/backend/tests/risk-edit.test.ts
@@ -1,0 +1,39 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { mockContext } from '../../test-support/test-data/test-utils.stub';
+import {
+  handler
+} from '../functions/risk-edit';
+
+describe('work package edit', () => {
+  describe('handler', () => {
+    const func = async (event: any) => {
+      return handler(event, mockContext, () => {});
+    };
+
+    describe('validate inputs', () => {
+      const goodBody = {
+        id: 1,
+        userId: 1,
+        detail: 'risk #1',
+        resolved: true
+      };
+
+      it ('fails when there is no risk id', async () => {
+        const { id, ... rest} = goodBody; 
+        const res = await func({ body: rest });
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toBe('Event object failed validation');
+      });
+
+      it ('fails when the invalid user is trying to edit risk', async () => {
+        const res = await func({ body: { ...goodBody, userId: -5 } });
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toBe('Event object failed validation');
+      });
+    });
+  });
+});

--- a/src/backend/tests/risk-edit.test.ts
+++ b/src/backend/tests/risk-edit.test.ts
@@ -6,7 +6,7 @@
 import { mockContext } from '../../test-support/test-data/test-utils.stub';
 import { handler } from '../functions/risk-edit';
 
-describe('work package edit', () => {
+describe('risk edit', () => {
   describe('handler', () => {
     const func = async (event: any) => {
       return handler(event, mockContext, () => {});
@@ -14,7 +14,7 @@ describe('work package edit', () => {
 
     describe('validate inputs', () => {
       const goodBody = {
-        id: 1,
+        id: 'ef14de-32bc7',
         userId: 1,
         detail: 'risk #1',
         resolved: true

--- a/src/backend/tests/risk-edit.test.ts
+++ b/src/backend/tests/risk-edit.test.ts
@@ -4,9 +4,7 @@
  */
 
 import { mockContext } from '../../test-support/test-data/test-utils.stub';
-import {
-  handler
-} from '../functions/risk-edit';
+import { handler } from '../functions/risk-edit';
 
 describe('work package edit', () => {
   describe('handler', () => {
@@ -22,14 +20,14 @@ describe('work package edit', () => {
         resolved: true
       };
 
-      it ('fails when there is no risk id', async () => {
-        const { id, ... rest} = goodBody; 
+      it('fails when there is no risk id', async () => {
+        const { id, ...rest } = goodBody;
         const res = await func({ body: rest });
         expect(res.statusCode).toBe(400);
         expect(res.body).toBe('Event object failed validation');
       });
 
-      it ('fails when the invalid user is trying to edit risk', async () => {
+      it('fails when the invalid user is trying to edit risk', async () => {
         const res = await func({ body: { ...goodBody, userId: -5 } });
         expect(res.statusCode).toBe(400);
         expect(res.body).toBe('Event object failed validation');

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './types/project-types';
 export * from './types/user-types';
 export * from './types/work-package-types';
 export * from './types/api-utils-types';
+export * from './types/risk-types';
 
 export * from './backend-supports/project-supports';
 

--- a/src/utils/src/types/risk-types.ts
+++ b/src/utils/src/types/risk-types.ts
@@ -4,13 +4,7 @@
  */
 
 import { FromSchema } from 'json-schema-to-ts';
-import {
-  bodySchema,
-  intType,
-  stringType,
-  booleanType
-} from './api-utils-types';
-
+import { bodySchema, intType, stringType, booleanType } from './api-utils-types';
 
 export const riskEditInputSchemaBody = bodySchema({
   userId: intType,

--- a/src/utils/src/types/risk-types.ts
+++ b/src/utils/src/types/risk-types.ts
@@ -8,7 +8,7 @@ import { bodySchema, intType, stringType, booleanType } from './api-utils-types'
 
 export const riskEditInputSchemaBody = bodySchema({
   userId: intType,
-  id: intType,
+  id: stringType,
   detail: stringType,
   resolved: booleanType
 });

--- a/src/utils/src/types/risk-types.ts
+++ b/src/utils/src/types/risk-types.ts
@@ -1,0 +1,22 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { FromSchema } from 'json-schema-to-ts';
+import {
+  bodySchema,
+  intType,
+  stringType,
+  booleanType
+} from './api-utils-types';
+
+
+export const riskEditInputSchemaBody = bodySchema({
+  userId: intType,
+  id: intType,
+  detail: stringType,
+  resolved: booleanType
+});
+
+export type EditRiskPayload = FromSchema<typeof riskEditInputSchemaBody>;


### PR DESCRIPTION
## Changes

I added three files (risk-edit.ts, risk-types.ts, and risk-edit.test.ts) to develop the endpoint for editing a risk. In risk-edit.ts, I validated incoming data using middy (riskEditInputSchemaBody from risk-types.ts), edited the selected risk from the database, and finally let this endpoint return the edited risk from the database. 

## Notes
Need to provide screenshots and test the endpoint manually to make sure the endpoint for editing risk works. 

## Test Cases

- Case A: Check if the event object fails (statuscode: 400) when the incoming inputs to the risk edit endpoint have no Risk id.
Result: Pass 
- Case B: Check if the event object fails (statuscode: 400) when the invalid user is trying to edit the Risk from the database. 
Result: Pass


## Screenshots (if applicable)

_Any relevant screenshots go here_

## To Do

_Any remaining things that need to get done_

- [x] Fix the error on lines 33 and 42 in risk-edit.ts
- [ ] Check up with the implementation of updating the risk from the database in risk-edit.ts
- [ ] Manually testing

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [x] All checks passing
- [ ] Screenshots of UI changes (if applicable)
- [ ] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x] No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes # (issue #)
