### PR TITLE
#767 - Risks.ts file and getRisks

### DIFF
--- a/src/backend/functions/risks.ts
+++ b/src/backend/functions/risks.ts
@@ -17,7 +17,8 @@ import {
   routeMatcher,
   User,
   Risk,
-  WbsNumber
+  WbsNumber,
+  UserPreview
 } from 'utils';
 
 const prisma = new PrismaClient();
@@ -37,6 +38,16 @@ const riskQueryArgs = Prisma.validator<Prisma.RiskArgs>()({
   }
 });
 
+const userTransformer = (user: Prisma.UserGetPayload<null>): UserPreview => {
+  return {
+    userId: user.userId,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+    role: user.role
+  };
+};
+
 const riskTransformer = (risk: Prisma.RiskGetPayload<typeof riskQueryArgs>): Risk => {
   return {
     id: risk.id,
@@ -47,14 +58,12 @@ const riskTransformer = (risk: Prisma.RiskGetPayload<typeof riskQueryArgs>): Ris
     },
     detail: risk.detail,
     isResolved: risk.isResolved,
+    dateDeleted: risk.dateDeleted ?? undefined,
     dateCreated: risk.dateCreated,
-    createdBy: {
-      userId: risk.createdBy.userId,
-      firstName: risk.createdBy.firstName,
-      lastName: risk.createdBy.lastName,
-      email: risk.createdBy.email,
-      role: risk.createdBy.role
-    }
+    createdBy: userTransformer(risk.createdBy),
+    resolvedBy: risk.resolvedBy ? userTransformer(risk.resolvedBy) : undefined,
+    resolvedAt: risk.resolvedAt ?? undefined,
+    deletedBy: risk.deletedBy ? userTransformer(risk.deletedBy) : undefined
   };
 };
 

--- a/src/backend/functions/risks.ts
+++ b/src/backend/functions/risks.ts
@@ -10,12 +10,10 @@ import {
   ApiRouteFunction,
   apiRoutes,
   API_URL,
-  buildClientFailureResponse,
   buildServerFailureResponse,
   buildNotFoundResponse,
   buildSuccessResponse,
   routeMatcher,
-  User,
   Risk,
   WbsNumber,
   UserPreview

--- a/src/backend/functions/risks.ts
+++ b/src/backend/functions/risks.ts
@@ -1,0 +1,96 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { Handler } from '@netlify/functions';
+import { Prisma, PrismaClient, WBS_Element } from '@prisma/client';
+import {
+  ApiRoute,
+  ApiRouteFunction,
+  apiRoutes,
+  API_URL,
+  buildClientFailureResponse,
+  buildServerFailureResponse,
+  buildNotFoundResponse,
+  buildSuccessResponse,
+  routeMatcher,
+  User,
+  Risk,
+  WbsNumber
+} from 'utils';
+
+const prisma = new PrismaClient();
+
+const wbsNumOf = (element: WBS_Element): WbsNumber => ({
+  carNumber: element.carNumber,
+  projectNumber: element.projectNumber,
+  workPackageNumber: element.workPackageNumber
+});
+
+const riskQueryArgs = Prisma.validator<Prisma.RiskArgs>()({
+  include: {
+    project: { include: { wbsElement: true } },
+    createdBy: true,
+    resolvedBy: true,
+    deletedBy: true
+  }
+});
+
+const riskTransformer = (risk: Prisma.RiskGetPayload<typeof riskQueryArgs>): Risk => {
+  return {
+    id: risk.id,
+    project: {
+      id: risk.project.projectId,
+      name: risk.project.wbsElement.name,
+      wbsNum: wbsNumOf(risk.project.wbsElement)
+    },
+    detail: risk.detail,
+    isResolved: risk.isResolved,
+    dateCreated: risk.dateCreated,
+    createdBy: {
+      userId: risk.createdBy.userId,
+      firstName: risk.createdBy.firstName,
+      lastName: risk.createdBy.lastName,
+      email: risk.createdBy.email,
+      role: risk.createdBy.role
+    }
+  };
+};
+
+const getRisksForProject: ApiRouteFunction = async (params: { projectId: string }) => {
+  const projectId = parseInt(params.projectId);
+  const requestedProject = await prisma.project.findUnique({
+    where: { projectId }
+  });
+
+  if (!requestedProject) return buildNotFoundResponse('project', `#${projectId}`);
+
+  const risks = await prisma.risk.findMany({
+    where: { projectId },
+    ...riskQueryArgs
+  });
+
+  return buildSuccessResponse(risks.map(riskTransformer));
+};
+
+// Define all valid routes for the endpoint
+const routes: ApiRoute[] = [
+  {
+    path: `${API_URL}${apiRoutes.RISKS_BY_PROJECT}`,
+    httpMethod: 'GET',
+    func: getRisksForProject
+  }
+];
+
+// Handler for incoming requests
+const handler: Handler = async (event, context) => {
+  try {
+    return routeMatcher(routes, event, context);
+  } catch (error: any) {
+    console.error(error);
+    return buildServerFailureResponse(error.message);
+  }
+};
+
+export { handler };

--- a/src/utils/src/api-routes.ts
+++ b/src/utils/src/api-routes.ts
@@ -27,6 +27,10 @@ const CHANGE_REQUESTS_NEW: string = `${CHANGE_REQUESTS}-new`;
 const CHANGE_REQUESTS_BY_ID: string = `${CHANGE_REQUESTS}/:id`;
 const CHANGE_REQUESTS_REVIEW: string = `${CHANGE_REQUESTS}-review`;
 
+/**************** Risks Endpoint ****************/
+const RISKS: string = `/risks`;
+const RISKS_BY_PROJECT: string = `${RISKS}/:projectId`;
+
 export const apiRoutes = {
   USERS,
   USERS_BY_ID,
@@ -44,5 +48,8 @@ export const apiRoutes = {
   CHANGE_REQUESTS,
   CHANGE_REQUESTS_NEW,
   CHANGE_REQUESTS_BY_ID,
-  CHANGE_REQUESTS_REVIEW
+  CHANGE_REQUESTS_REVIEW,
+
+  RISKS,
+  RISKS_BY_PROJECT
 };

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -8,6 +8,7 @@ export * from './types/project-types';
 export * from './types/user-types';
 export * from './types/work-package-types';
 export * from './types/api-utils-types';
+export * from './types/risk-types';
 
 export * from './backend-supports/project-supports';
 

--- a/src/utils/src/types/project-types.ts
+++ b/src/utils/src/types/project-types.ts
@@ -47,6 +47,8 @@ export interface Project extends WbsElement {
   workPackages: WorkPackage[];
 }
 
+export type ProjectPreview = Pick<Project, 'id' | 'name' | 'wbsNum'>;
+
 export interface WorkPackage extends WbsElement {
   orderInProject: number;
   progress: number;

--- a/src/utils/src/types/risk-types.ts
+++ b/src/utils/src/types/risk-types.ts
@@ -1,0 +1,20 @@
+/*
+ * This file is part of NER's PM Dashboard and licensed under GNU AGPLv3.
+ * See the LICENSE file in the repository root folder for details.
+ */
+
+import { ProjectPreview } from './project-types';
+import { UserPreview } from './user-types';
+
+export interface Risk {
+  id: String;
+  project: ProjectPreview;
+  detail: string;
+  isResolved: boolean;
+  dateDeleted?: Date;
+  dateCreated: Date;
+  createdBy: UserPreview;
+  resolvedBy?: UserPreview;
+  resolvedAt?: Date;
+  deletedBy?: UserPreview;
+}

--- a/src/utils/src/types/user-types.ts
+++ b/src/utils/src/types/user-types.ts
@@ -13,4 +13,6 @@ export interface User {
   role: Role;
 }
 
+export type UserPreview = Pick<User, 'userId' | 'firstName' | 'lastName' | 'email' | 'role'>;
+
 export type Role = 'APP_ADMIN' | 'ADMIN' | 'LEADERSHIP' | 'MEMBER' | 'GUEST';


### PR DESCRIPTION
## Changes

Added a risks.ts file and the get risks by project id endpoint

## Notes

it can be argued that this endpoint is unneeded and should be part of the return values of projects. That could be true, but this prevents changing a lot of code which is nice. I also just wanted the risks.ts file to be up and running for some of the other prs and stuff

## Test Cases

manually tested that it works when I go to localhost:3000/.netlify/functions/risks/2 -- didn't try with any data though lol

Closes #767