### PR TITLE
#779 - Added integer checks to numerical fields Timeline and Budget I…

### DIFF
--- a/src/frontend/pages/CreateChangeRequestPage/create-change-request-view.tsx
+++ b/src/frontend/pages/CreateChangeRequestPage/create-change-request-view.tsx
@@ -40,12 +40,14 @@ const schema = yup.object().shape({
     .number()
     .typeError('Timeline Impact must be a number')
     .min(0, 'Timeline Impact must be greater than or equal to 0 weeks')
-    .required('Timeline Impact is required'),
+    .required('Timeline Impact is required')
+    .integer('Timeline Impact must be an integer'),
   budgetImpact: yup
     .number()
     .typeError('Budget Impact must be a number')
     .min(0, 'Budget Impact must be greater than or equal to $0')
-    .required('Budget Impact is required'),
+    .required('Budget Impact is required')
+    .integer('Budget Impact must be an integer'),
   why: yup
     .array()
     .min(1, 'At least one Why is required')


### PR DESCRIPTION
…mpact

## Changes

Added checks for integer values when creating change requests to prevent decimal inputs in Timeline/Budget Impact fields.

## Notes

_Any other notes go here_

## Test Cases
None (tests for create change request page seem scarce?)

## Screenshots (if applicable)

<img width="547" alt="Screen Shot 2022-08-11 at 1 09 35 AM" src="https://user-images.githubusercontent.com/59621104/184068297-f86907b3-061e-4dd3-9463-32955dd44c74.png">


## To Do
None? Does it make sense for things to only be integers? Should we allow people to add 1.5 weeks or a couple of cents to the budget?
## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://github.com/Northeastern-Electric-Racing/PM-Dashboard-v2/blob/main/docs/ContributorGuide.md) and reach out to your squad if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors
- [x] No newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (if applicable)
- [x] Remove any not-applicable sections
- [x] Assign the PR to yourself
- [x] PR is linked to the ticket
- [x]  No `package-lock.json` changes (unless dependencies have changed)
- [x] Request reviewers & ping on Slack

Closes Northeastern-Electric-Racing/FinishLine#81 
